### PR TITLE
Reformat, rearrange/remove try catch methods, remove inherited types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ out
 
 # IDE
 .idea
+*.iml

--- a/src/org/vitrivr/cthulhu/cineast/config/CineastConfig.java
+++ b/src/org/vitrivr/cthulhu/cineast/config/CineastConfig.java
@@ -1,0 +1,15 @@
+package org.vitrivr.cthulhu.cineast.config;
+
+import java.util.List;
+
+public class CineastConfig {
+
+  public CineastInput input;
+  public List<CineastFeature> features;
+  public List<CineastFeature> exporters;
+  public CineastDBConfig database;
+  public String retriever;
+  public String decoder;
+  public CineastExtractorConfig extractor;
+  public String imagecache;
+}

--- a/src/org/vitrivr/cthulhu/cineast/config/CineastDBConfig.java
+++ b/src/org/vitrivr/cthulhu/cineast/config/CineastDBConfig.java
@@ -1,0 +1,9 @@
+package org.vitrivr.cthulhu.cineast.config;
+
+public class CineastDBConfig {
+
+  public String host;
+  public int port;
+  public boolean plaintext;
+  public String writer;
+}

--- a/src/org/vitrivr/cthulhu/cineast/config/CineastExtractorConfig.java
+++ b/src/org/vitrivr/cthulhu/cineast/config/CineastExtractorConfig.java
@@ -1,0 +1,9 @@
+package org.vitrivr.cthulhu.cineast.config;
+
+public class CineastExtractorConfig {
+
+  public int shotQueueSize;
+  public int threadPoolSize;
+  public int taskQueueSize;
+  public String outputLocation;
+}

--- a/src/org/vitrivr/cthulhu/cineast/config/CineastFeature.java
+++ b/src/org/vitrivr/cthulhu/cineast/config/CineastFeature.java
@@ -1,0 +1,11 @@
+package org.vitrivr.cthulhu.cineast.config;
+
+import com.google.gson.annotations.SerializedName;
+
+public class CineastFeature {
+
+  public String name;
+  @SerializedName("class")
+  public String _class;
+  public String config;
+}

--- a/src/org/vitrivr/cthulhu/cineast/config/CineastInput.java
+++ b/src/org/vitrivr/cthulhu/cineast/config/CineastInput.java
@@ -1,0 +1,13 @@
+package org.vitrivr.cthulhu.cineast.config;
+
+import java.util.List;
+
+public class CineastInput {
+
+  public String folder;
+  public String file;
+  public List<String> subtitles;
+  public String id;
+  public String name;
+
+}

--- a/src/org/vitrivr/cthulhu/jobs/BashJob.java
+++ b/src/org/vitrivr/cthulhu/jobs/BashJob.java
@@ -14,16 +14,13 @@ public class BashJob extends Job {
   }
 
   protected BashJob(String action) {
-    super();
-    this.action = action;
-    this.type = "BashJob";
+    this(action, 2);
   }
 
   protected BashJob(String action, int priority) {
     super();
     this.action = action;
     this.priority = priority;
-    this.type = "BashJob";
   }
 
   public int execute() {

--- a/src/org/vitrivr/cthulhu/jobs/BashJob.java
+++ b/src/org/vitrivr/cthulhu/jobs/BashJob.java
@@ -1,72 +1,56 @@
 package org.vitrivr.cthulhu.jobs;
 
-import java.lang.ProcessBuilder;
-import java.lang.Process;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.Charset;
 import org.apache.commons.io.IOUtils;
 
-import java.lang.InterruptedException;
-import java.io.IOException;
-
 
 public class BashJob extends Job {
-    String stdOut;
-    String stdErr;
 
-    protected BashJob(){
-        super();
+  protected BashJob() {
+    super();
+  }
+
+  protected BashJob(String action) {
+    super();
+    this.action = action;
+    this.type = "BashJob";
+  }
+
+  protected BashJob(String action, int priority) {
+    super();
+    this.action = action;
+    this.priority = priority;
+    this.type = "BashJob";
+  }
+
+  public int execute() {
+    ProcessBuilder pb = new ProcessBuilder("sh");
+    Process p;
+    try {
+      p = pb.start();
+      OutputStream os = p.getOutputStream();
+      os.write(this.action.getBytes(Charset.forName("UTF-8")));
+      os.flush();
+      os.close();
+
+      InputStream is = p.getInputStream();
+      InputStream es = p.getErrorStream();
+
+      this.stdOut = IOUtils.toString(is, "UTF-8");
+      this.stdErr = IOUtils.toString(es, "UTF-8");
+      int retVal = p.waitFor();
+      if (retVal == 0) {
+        status = Job.Status.SUCCEEDED;
+      }
+    } catch (IOException e) {
+      status = Job.Status.FAILED;
+      return status.getValue();
+    } catch (InterruptedException e) {
+      status = Job.Status.INTERRUPTED;
     }
-
-    protected BashJob(String action) {
-        super();
-        this.action = action;
-        this.type = "BashJob";
-    }
-    protected BashJob(String action, int priority) {
-        super();
-        this.action = action;
-        this.priority = priority;
-        this.type = "BashJob";
-    }
-
-    public int execute() {
-        ProcessBuilder pb = new ProcessBuilder("sh");
-        Process p;
-        int retVal = 1; //Error unless changed later on
-        try {
-            p = pb.start();
-            OutputStream os = p.getOutputStream();
-            os.write(this.action.getBytes(Charset.forName("UTF-8")));
-            os.flush();
-            os.close();
-
-            InputStream is = p.getInputStream();
-            InputStream es = p.getErrorStream();
-            
-            this.stdOut = IOUtils.toString(is,"UTF-8");
-            this.stdErr = IOUtils.toString(es,"UTF-8");
-        } catch (IOException e) {
-            status = Job.Status.FAILED;
-            return status.getValue();
-        }
-        try {
-            retVal = p.waitFor();
-            if(retVal == 0) status = Job.Status.SUCCEEDED;
-        } catch (InterruptedException e) {
-            status = Job.Status.INTERRUPTED;
-        } finally {
-            return status.getValue();
-        }
-    }
-
-    /**
-     * Returns the standard output of a job after it ran
-     */
-    public String getStdOut() { return stdOut; }
-    /**
-     * Returns the standard error stream contents of a job after it ran
-     */
-    public String getStdErr() { return stdErr; }
+    return status.getValue();
+  }
 }

--- a/src/org/vitrivr/cthulhu/jobs/FeatureExtractionJob.java
+++ b/src/org/vitrivr/cthulhu/jobs/FeatureExtractionJob.java
@@ -1,191 +1,168 @@
 package org.vitrivr.cthulhu.jobs;
 
-import java.util.List;
-import java.util.Set;
-import java.util.HashSet;
-import java.util.Arrays;
-
-import java.io.InputStream;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import java.io.File;
-import java.io.Writer;
 import java.io.FileWriter;
 import java.io.IOException;
-
+import java.io.InputStream;
+import java.io.Writer;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 import org.apache.commons.io.IOUtils;
-
-import java.lang.Process;
-
-import com.google.gson.GsonBuilder;
-import com.google.gson.Gson;
-import com.google.gson.annotations.SerializedName;
-
-import java.util.stream.*;
+import org.vitrivr.cthulhu.cineast.config.CineastConfig;
+import org.vitrivr.cthulhu.cineast.config.CineastExtractorConfig;
 
 public class FeatureExtractionJob extends Job {
-    CineastConfig config;
-    String stdOut;
-    String stdErr;
-    String note;
-    boolean immediate_cleanup = true;
-    boolean return_zipfile = false;
-    /**
-     * The working directory of the job. If it's set, then it won't be recreated.
-     * Files that are already in the working directory will override remote server files.
-     */
-    String workDir = null;
-    public int execute() {
-        if(tools == null) {
-            this.status = Status.UNEXPECTED_ERROR;
-            return 1;
-        }
-        if(tools != null && (workDir == null || workDir.isEmpty())) {
-            tools.lg.info("{} - Setting up the working directory.", name);
-            workDir = tools.setWorkingDirectory(this);
-        }
-        tools.lg.info("{} - Working directory is {}.", name, workDir);
-        obtainInputFiles(workDir);
-        String cf = generateConfigFile(workDir);
-        executeCineast(cf);
-        if(return_zipfile) returnResult();
-        else tools.lg.info("{} - Results will not be returned to cooridnator");
-        if(immediate_cleanup) deleteWorkingDirectory();
-        else tools.lg.info("{} - No cleanup to be done",name);
-        return status.getValue();
-    }
-    protected void returnResult() {
-        String newfileName = 
-            config.input.file.substring(0,config.input.file.indexOf("."))+"_result.zip";
-        try {
-            tools.sendZipDirectory(workDir, newfileName);
-        } catch (Exception e) {
-            tools.lg.error("{} - Failed to send zipped results: {}", name, e.toString());
-            note = (note == null ? "" : note + " ; ") + "Unable to send zipped results to coordinator";
-        }
-    }
-    protected void deleteWorkingDirectory() {
-        tools.lg.info("{} - Deleting the working directory", name);
-        File dir = new File(workDir);
-        try {
-            tools.delete(dir);
-        } catch (Exception e) {
-            note = (note == null ? "" : note + " ; ") + "Unable to delete the working directory "+workDir;
-            tools.lg.warn("{} - Unable to delete the working directory: {}", name, e.toString());
-        }
-    }
-    private void obtainInputFiles(String workingDir) {
-        if(config == null || config.input == null) return;
-        File wdf = new File(workingDir);
-        File inpf = new File(wdf, config.input.file);
-        String inpStr = inpf.getName();
-        Set<String> dirFiles = new HashSet<String>(Arrays.asList(wdf.list()));
-        if(!dirFiles.contains(inpStr)) {
-            tools.lg.debug("{} - Obtaining file {}", name, config.input.file);
-            if(!tools.getFile(config.input.file, workingDir)) {
-                tools.lg.error("{} - Trouble getting file {}",name,config.input.file);
-                status = Status.UNEXPECTED_ERROR;
-                note = (note == null ? "" : note + " ; ") + "Unable to get remote files";
-            }
-        }
-        config.input.folder = wdf.getAbsolutePath();
-        if(config.input.subtitles != null) {
-            config.input.subtitles.stream().forEach(s-> {
-                    File subf = new File(wdf,s);
-                    String fnme = subf.getName();
-                    tools.lg.debug("{} - Obtaining file {}", name, fnme);
-                    if(!dirFiles.contains(fnme)) {
-                        if(!tools.getFile(s, workingDir) && status != Status.UNEXPECTED_ERROR) {
-                            tools.lg.error("{} - Unable to get remote file {}", name, fnme);
-                            status = Status.UNEXPECTED_ERROR;
-                            note = (note == null ? "" : note + " ; ") + "Unable to get remote files";
-                        }
-                    }
-                });
-        }
-        tools.lg.info("{} - Obtained allremote files.", name);
-    }
-    private String generateConfigFile(String workingDir) {
-        String confileName = workingDir+"/"+name+"_config.json";
-        if(config == null) return null;
-        if(config.extractor == null) config.extractor = new CineastExtractorConfig();
-        if(config.extractor.outputLocation == null) config.extractor.outputLocation = new File(workingDir).getAbsolutePath();
-        tools.lg.info("{} - Generating config file in {}",name, confileName);
-        try {
-            Writer writer = new FileWriter(confileName);
-            Gson gson = new GsonBuilder().create();
-            gson.toJson(config, writer);
-            writer.close();
-        } catch (IOException io) {
-            tools.lg.error("{} - Unable to generate a config file.", name);
-        }
-        return confileName;
-    }
-    private void executeCineast(String cfile) {
-        String cineastDir = tools.getCineastLocation();
-        tools.lg.info("{} - Preparing to execute cineast",name);
-        if(cineastDir == null || cineastDir.isEmpty()) return ;
-        String javaFlags = tools.getJavaFlags();
-        String command = "java " + javaFlags + " -jar "+ cineastDir + " --job " + cfile;
-        //System.out.println("Command: "+command);
-        try {
-            tools.lg.debug("{} - Preparing to create process",name);
-            Process p = Runtime.getRuntime().exec(command);
-            InputStream is = p.getInputStream();
-            InputStream es = p.getErrorStream();
-            tools.lg.debug("{} - Starting to collect input/output stream",name);
-            this.stdOut = IOUtils.toString(is,"UTF-8");
-            this.stdErr = IOUtils.toString(es,"UTF-8");
-            tools.lg.debug("{} - Done collecting input/output stream",name);
-            //System.out.println("SDOUT: "+stdOut);
-            //System.out.println("SDERR: "+stdErr);
-            int retVal = p.waitFor();
-            if(retVal == 0) status = Job.Status.SUCCEEDED;
-        } catch (InterruptedException e) {
-            status = Job.Status.INTERRUPTED;
-            tools.lg.warn("{} - Job has been interrupted",name);
-        } catch (Exception e) {
-            status = Job.Status.FAILED;
-            tools.lg.error("{} - Exception occurred during execution: {}", name, e,toString());
-        }
-        tools.lg.info("{} - Execution of cineast finalized",name);
-    }
-}
 
-class CineastConfig {
-    CineastInput input;
-    List<CineastFeature> features;
-    List<CineastFeature> exporters;
-    CineastDBConfig database;
-    String retriever;
-    String decoder;
-    CineastExtractorConfig extractor;
-    String imagecache;
-}
+  CineastConfig config;
+  String note;
+  boolean immediate_cleanup = true;
+  boolean return_zipfile = false;
+  /**
+   * The working directory of the job. If it's set, then it won't be recreated. Files that are
+   * already in the working directory will override remote server files.
+   */
+  String workDir = null;
 
-class CineastInput {
-    String id;
-    protected String folder;
-    protected String file;
-    String name;
-    protected List<String> subtitles;
-}
+  public int execute() {
+    if (tools == null) {
+      this.status = Status.UNEXPECTED_ERROR;
+      return 1;
+    }
+    if (workDir == null || workDir.isEmpty()) {
+      tools.lg.info("{} - Setting up the working directory.", name);
+      workDir = tools.setWorkingDirectory(this);
+    }
+    tools.lg.info("{} - Working directory is {}.", name, workDir);
+    obtainInputFiles(workDir);
+    String cf = generateConfigFile(workDir);
+    executeCineast(cf);
+    if (return_zipfile) {
+      returnResult();
+    } else {
+      tools.lg.info("{} - Results will not be returned to coordinator");
+    }
+    if (immediate_cleanup) {
+      deleteWorkingDirectory();
+    } else {
+      tools.lg.info("{} - No cleanup to be done", name);
+    }
+    return status.getValue();
+  }
 
-class CineastExtractorConfig {
-    Integer shotQueueSize;
-    Integer threadPoolSize;
-    Integer taskQueueSize;
-    String outputLocation;
-}
+  protected void returnResult() {
+    String newfileName =
+        config.input.file.substring(0, config.input.file.indexOf(".")) + "_result.zip";
+    try {
+      tools.sendZipDirectory(workDir, newfileName);
+    } catch (Exception e) {
+      tools.lg.error("{} - Failed to send zipped results: {}", name, e.toString());
+      note = (note == null ? "" : note + " ; ") + "Unable to send zipped results to coordinator";
+    }
+  }
 
-class CineastDBConfig {
-    String host;
-    int port;
-    boolean plaintext;
-    String writer;
-}
+  protected void deleteWorkingDirectory() {
+    tools.lg.info("{} - Deleting the working directory", name);
+    File dir = new File(workDir);
+    try {
+      tools.delete(dir);
+    } catch (Exception e) {
+      note =
+          (note == null ? "" : note + " ; ") + "Unable to delete the working directory " + workDir;
+      tools.lg.warn("{} - Unable to delete the working directory: {}", name, e.toString());
+    }
+  }
 
-class CineastFeature {
-    String name;
-    @SerializedName("class")
-    String _class;
-    String config;
+  private void obtainInputFiles(String workingDir) {
+    if (config == null || config.input == null) {
+      return;
+    }
+    File wdf = new File(workingDir);
+    File inpf = new File(wdf, config.input.file);
+    String inpStr = inpf.getName();
+    Set<String> dirFiles = new HashSet<>(Arrays.asList(wdf.list()));
+    if (!dirFiles.contains(inpStr)) {
+      tools.lg.debug("{} - Obtaining file {}", name, config.input.file);
+      if (!tools.getFile(config.input.file, workingDir)) {
+        tools.lg.error("{} - Trouble getting file {}", name, config.input.file);
+        status = Status.UNEXPECTED_ERROR;
+        note = (note == null ? "" : note + " ; ") + "Unable to get remote files";
+      }
+    }
+    config.input.folder = wdf.getAbsolutePath();
+    if (config.input.subtitles != null) {
+      config.input.subtitles.stream().forEach(s -> {
+        File subf = new File(wdf, s);
+        String fnme = subf.getName();
+        tools.lg.debug("{} - Obtaining file {}", name, fnme);
+        if (!dirFiles.contains(fnme)) {
+          if (!tools.getFile(s, workingDir) && status != Status.UNEXPECTED_ERROR) {
+            tools.lg.error("{} - Unable to get remote file {}", name, fnme);
+            status = Status.UNEXPECTED_ERROR;
+            note = (note == null ? "" : note + " ; ") + "Unable to get remote files";
+          }
+        }
+      });
+    }
+    tools.lg.info("{} - Obtained allremote files.", name);
+  }
+
+  private String generateConfigFile(String workingDir) {
+    String confileName = workingDir + "/" + name + "_config.json";
+    if (config == null) {
+      return null;
+    }
+    if (config.extractor == null) {
+      config.extractor = new CineastExtractorConfig();
+    }
+    if (config.extractor.outputLocation == null) {
+      config.extractor.outputLocation = new File(workingDir).getAbsolutePath();
+    }
+    tools.lg.info("{} - Generating config file in {}", name, confileName);
+    try {
+      Writer writer = new FileWriter(confileName);
+      Gson gson = new GsonBuilder().create();
+      gson.toJson(config, writer);
+      writer.close();
+    } catch (IOException io) {
+      tools.lg.error("{} - Unable to generate a config file.", name);
+    }
+    return confileName;
+  }
+
+  private void executeCineast(String cfile) {
+    String cineastDir = tools.getCineastLocation();
+    tools.lg.info("{} - Preparing to execute cineast", name);
+    if (cineastDir == null || cineastDir.isEmpty()) {
+      return;
+    }
+    String javaFlags = tools.getJavaFlags();
+    String command = "java " + javaFlags + " -jar " + cineastDir + " --job " + cfile;
+    //System.out.println("Command: "+command);
+    try {
+      tools.lg.debug("{} - Preparing to create process", name);
+      Process p = Runtime.getRuntime().exec(command);
+      InputStream is = p.getInputStream();
+      InputStream es = p.getErrorStream();
+      tools.lg.debug("{} - Starting to collect input/output stream", name);
+      this.stdOut = IOUtils.toString(is, "UTF-8");
+      this.stdErr = IOUtils.toString(es, "UTF-8");
+      tools.lg.debug("{} - Done collecting input/output stream", name);
+      //System.out.println("SDOUT: "+stdOut);
+      //System.out.println("SDERR: "+stdErr);
+      int retVal = p.waitFor();
+      if (retVal == 0) {
+        status = Job.Status.SUCCEEDED;
+      }
+    } catch (InterruptedException e) {
+      status = Job.Status.INTERRUPTED;
+      tools.lg.warn("{} - Job has been interrupted", name);
+    } catch (Exception e) {
+      status = Job.Status.FAILED;
+      tools.lg.error("{} - Exception occurred during execution: {}", name, e, toString());
+    }
+    tools.lg.info("{} - Execution of cineast finalized", name);
+  }
 }

--- a/src/org/vitrivr/cthulhu/jobs/Job.java
+++ b/src/org/vitrivr/cthulhu/jobs/Job.java
@@ -4,190 +4,220 @@ import com.google.gson.Gson;
 import java.time.LocalDateTime;
 
 /**
-   The Job interface. Defines the basic methods for jobs to be manipulated.
+ * The Job interface. Defines the basic methods for jobs to be manipulated.
  */
-abstract public class Job implements Comparable<Job>{
-    public enum Status {
-        SUCCEEDED(0),  // Failure in the job
-        FAILED(1),   // Job failed while running
-        WAITING(2), // Job has been created, but it has not been run.
-        INTERRUPTED(3), // The job received an interruption while running
-        UNEXPECTED_ERROR(4), // Failure from our program
-        RUNNING(5);
-        private final int value;
-        Status (final int newValue) {
-            value = newValue;
-        }
-        public int getValue() { return value; }
-    }
-    transient JobTools tools;
-    String type;
-    String name;
-    String action;
-    protected void setTools(JobTools tools) {
-        this.tools = tools;
-    }
-    /**
-     * Documents the status of the job. Possible statuses are:
-     * <b>SUCCEEDED, FAILED, WAITING, INTERRUPTED, UNEXPECTED_ERROR, RUNNING</b>;
-     * where each one should be self-explanatory.
-     */
-    Status status = Status.WAITING;
-    LocalDateTime created_at;
-    int priority = 2; // Default priority is 2
-    /**
-     * Executes the job.
-     * <p>
-     * It is the main routine called to execute a job.
-     * It returns an int with the status of the job (0:SUCCESS,1:FAILED)
-     */
-    abstract public int execute();
+abstract public class Job implements Comparable<Job> {
 
-    /**
-     * Creates a job without arguments
-     */
-    public Job() {
-        created_at = LocalDateTime.now();
+  String stdOut;
+  String stdErr;
+  transient JobTools tools;
+  String type;
+  String name;
+  String action;
+  /**
+   * Documents the status of the job. Possible statuses are:
+   * <b>SUCCEEDED, FAILED, WAITING, INTERRUPTED, UNEXPECTED_ERROR, RUNNING</b>;
+   * where each one should be self-explanatory.
+   */
+  Status status = Status.WAITING;
+  private LocalDateTime created_at;
+  int priority = 2; // Default priority is 2
+  /**
+   * Creates a job without arguments
+   */
+  public Job() {
+    created_at = LocalDateTime.now();
+  }
+
+  protected void setTools(JobTools tools) {
+    this.tools = tools;
+  }
+
+  /**
+   * Executes the job.
+   * <p>
+   * It is the main routine called to execute a job. It returns an int with the status of the job
+   * (0:SUCCESS,1:FAILED)
+   */
+  abstract public int execute();
+
+  /**
+   * Checks if the job is running
+   * <p>
+   *
+   * @return True if the job is running, false otherwise.
+   */
+  public boolean isRunning() {
+    return status == Status.RUNNING;
+  }
+
+  /**
+   * Checks if the job was interrupted
+   * <p>
+   *
+   * @return True if the job was interrupted, false otherwise.
+   */
+  public boolean wasInterrupted() {
+    return status == Status.INTERRUPTED;
+  }
+
+  /**
+   * Checks the status of the job
+   * <p>
+   *
+   * @return An integer representing the value of the job status see {@link Status Status}.
+   */
+  public int getStatus() {
+    return status.getValue();
+  }
+
+  /**
+   * Sets the job status as RUNNING
+   * <p>
+   */
+  public void setRunning() {
+    status = Status.RUNNING;
+  }
+
+  /**
+   * Sets the job status as WAITING
+   * <p>
+   */
+  public void setWaiting() {
+    status = Status.WAITING;
+  }
+
+  /**
+   * Returns the type of the job.
+   * <p>
+   *
+   * @return The job type (BashJob, FeatureExtractionJob,...)
+   */
+  public String getType() {
+    return type;
+  }
+
+  /**
+   * Returns the action property of the job. The main action of it.
+   * <p>
+   *
+   * @return the action property of the job
+   */
+  public String getAction() {
+    return action;
+  }
+
+  /**
+   * Returns the priority of the job.
+   * <p>
+   *
+   * @return the priority of the job (smaller is better)
+   */
+  public int getPriority() {
+    return priority;
+  }
+
+  /**
+   * Modifies the priority of the job
+   * <p>
+   *
+   * @param priority the new priority of the job
+   */
+  public void setPriority(int priority) {
+    this.priority = priority;
+  }
+
+  /**
+   * Returns whether the job is waiting to run.
+   * <p>
+   *
+   * @return true if the job status is WAITING, false otherwise
+   */
+  public boolean isWaiting() {
+    return this.status == Status.WAITING;
+  }
+
+  /**
+   * Returns the name of the job
+   * <p>
+   *
+   * @return the name of the job
+   */
+  public String getName() {
+    return name;
+  }
+
+  /**
+   * Returns the JSON representation of the job
+   * <p>
+   *
+   * @return the JSON representation of the job
+   */
+  public String toString() {
+    Gson gson = new Gson();
+    return gson.toJson(this);
+  }
+
+  /**
+   * Returns the time a job was created
+   * <p>
+   *
+   * @return the time a job was created
+   */
+  private LocalDateTime getCreatedAt() {
+    return created_at;
+  }
+
+  /**
+   * Compares two jobs for priority and creation time. If priority is smaller, then the job is
+   * considered 'smaller'. If priority is the same, then jobs created earlier are considered
+   * 'smaller'.
+   * <p>
+   *
+   * @return 1 if our job is bigger, -1 if it's smaller. 0 if it is equal.
+   */
+  public int compareTo(Job o) {
+    if (priority > o.getPriority()) {
+      return 1;
+    }
+    if (priority == o.getPriority() && created_at.compareTo(o.getCreatedAt()) > 0) {
+      return 1;
+    }
+    if (priority == o.getPriority() && created_at.compareTo(o.getCreatedAt()) == 0) {
+      return 0;
+    }
+    return -1;
+  }
+
+  public enum Status {
+    SUCCEEDED(0),  // Failure in the job
+    FAILED(1),   // Job failed while running
+    WAITING(2), // Job has been created, but it has not been run.
+    INTERRUPTED(3), // The job received an interruption while running
+    UNEXPECTED_ERROR(4), // Failure from our program
+    RUNNING(5);
+    private final int value;
+
+    Status(final int newValue) {
+      value = newValue;
     }
 
-    /**
-     * Checks if the job is running
-     * <p>
-     *
-     * @return True if the job is running, false otherwise.
-     */
-    public boolean isRunning() {
-        return status == Status.RUNNING;
+    public int getValue() {
+      return value;
     }
+  }
 
-    /**
-     * Checks if the job was interrupted
-     * <p>
-     *
-     * @return True if the job was interrupted, false otherwise.
-     */
-    public boolean wasInterrupted() {
-        return status == Status.INTERRUPTED;
-    }
+  /**
+   * Returns the standard output of a job after it ran
+   */
+  String getStdOut() {
+    return stdOut;
+  }
 
-    /**
-     * Checks the status of the job
-     * <p>
-     *
-     * @return An integer representing the value of the job status see {@link #Status Status}.
-     */
-    public int getStatus() {
-        return status.getValue();
-    }
-
-    /**
-     * Sets the job status as RUNNING
-     * <p>
-     */
-    public void setRunning() {
-        status = Status.RUNNING;
-    }
-    /**
-     * Sets the job status as WAITING
-     * <p>
-     */
-    public void setWaiting() {
-        status = Status.WAITING;
-    }
-    
-    /**
-     * Returns the type of the job.
-     * <p>
-     *
-     * @return The job type (BashJob, FeatureExtractionJob,...)
-     */
-    public String getType(){
-        return type;
-    }
-
-    /**
-     * Returns the action property of the job. The main action of it.
-     * <p>
-     *
-     * @return the action property of the job
-     */
-    public String getAction() {
-        return action;
-    }
-
-    /**
-     * Returns the priority of the job.
-     * <p>
-     *
-     * @return the priority of the job (smaller is better)
-     */
-    public int getPriority(){
-        return priority;
-    }
-
-    /**
-     * Returns whether the job is waiting to run.
-     * <p>
-     *
-     * @return true if the job status is WAITING, false otherwise
-     */
-    public boolean isWaiting() {
-        return this.status == Status.WAITING;
-    }
-
-    /**
-     * Modifies the priority of the job
-     * <p>
-     *
-     * @param the new priority of the job
-     */
-    public void setPriority(int priority){
-        this.priority = priority;
-    }
-
-    /**
-     * Returns the name of the job
-     * <p>
-     *
-     * @return the name of the job
-     */
-    public String getName() {
-        return name;
-    }
-
-    /**
-     * Returns the JSON representation of the job
-     * <p>
-     *
-     * @return the JSON representation of the job
-     */
-    public String toString() {
-        Gson gson = new Gson();
-        String json = gson.toJson(this);
-        return json;
-    }
-
-    /**
-     * Returns the time a job was created
-     * <p>
-     *
-     * @return the time a job was created
-     */
-    public LocalDateTime getCreatedAt() {
-        return created_at;
-    }
-
-    /**
-     * Compares two jobs for priority and creation time. If priority is smaller, then the job is
-     * considered 'smaller'. If priority is the same, then jobs created earlier are considered 'smaller'.
-     * <p>
-     *
-     * @return 1 if our job is bigger, -1 if it's smaller. 0 if it is equal.
-     */
-    public int compareTo(Job o) {
-        if(priority > o.getPriority()) return 1;
-        if(priority == o.getPriority() && created_at.compareTo(o.getCreatedAt()) == 1) return 1;
-        if(priority == o.getPriority() && created_at.compareTo(o.getCreatedAt()) == 0) return 0;
-        return -1;
-    }
+  /**
+   * Returns the standard error stream contents of a job after it ran
+   */
+  String getStdErr() {
+    return stdErr;
+  }
 }

--- a/src/org/vitrivr/cthulhu/jobs/JobAdapter.java
+++ b/src/org/vitrivr/cthulhu/jobs/JobAdapter.java
@@ -1,57 +1,58 @@
 package org.vitrivr.cthulhu.jobs;
 
-import org.vitrivr.cthulhu.jobs.*;
-
-import com.google.gson.GsonBuilder;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import com.google.gson.JsonSerializationContext;
-import com.google.gson.JsonDeserializationContext;
-import com.google.gson.JsonSerializer;
-import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonParseException;
-
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
 import java.lang.reflect.Type;
 
 /**
- * Implements a serializing and deserializing infrastructure for jobs
- * and their subclasses.
- * Requires Job.type to be equal to its class name.
+ * Implements a serializing and deserializing infrastructure for jobs and their subclasses. Requires
+ * Job.type to be equal to its class name.
  */
 public final class JobAdapter implements JsonSerializer<Job>, JsonDeserializer<Job> {
-    /**
-     * Serializes the job. Normal Gson behavior.
-     * <p>
-     */
-    public JsonElement serialize(Job object, Type interfaceType, JsonSerializationContext context) {
-        final JsonObject wrapper = new JsonObject();
-        return context.serialize(object).getAsJsonObject(); // Serialize normally - the type is part of the object
-    }
 
-    /**
-     * Deserializes a JSON definition of a job. It selects the Class of the object it creates with the type
-     * parameter of the JSON definition.
-     * <p>
-     * It REQUIRES a type parameter in the Job definition.
-     */
-    public Job deserialize(JsonElement elem, Type interfaceType, JsonDeserializationContext context) throws JsonParseException {
-        final JsonObject wrapper = (JsonObject) elem;
-        final JsonElement typeName = get(wrapper, "type");
-        final Type actualType = typeForName(typeName); 
-        return context.deserialize(elem, actualType);
-    }
+  /**
+   * Serializes the job. Normal Gson behavior.
+   * <p>
+   */
+  public JsonElement serialize(Job object, Type interfaceType, JsonSerializationContext context) {
+    final JsonObject wrapper = new JsonObject();
+    return context.serialize(object)
+        .getAsJsonObject(); // Serialize normally - the type is part of the object
+  }
 
-    private Type typeForName(final JsonElement typeElem) {
-        try {
-            return Class.forName("org.vitrivr.cthulhu.jobs."+typeElem.getAsString());
-        } catch (ClassNotFoundException e) {
-            throw new JsonParseException(e);
-        }
-    }
+  /**
+   * Deserializes a JSON definition of a job. It selects the Class of the object it creates with the
+   * type parameter of the JSON definition.
+   * <p>
+   * It REQUIRES a type parameter in the Job definition.
+   */
+  public Job deserialize(JsonElement elem, Type interfaceType, JsonDeserializationContext context)
+      throws JsonParseException {
+    final JsonObject wrapper = (JsonObject) elem;
+    final JsonElement typeName = get(wrapper, "type");
+    final Type actualType = typeForName(typeName);
+    return context.deserialize(elem, actualType);
+  }
 
-    private JsonElement get(final JsonObject wrapper, String memberName) {
-        final JsonElement elem = wrapper.get(memberName);
-        if (elem == null) throw new JsonParseException("no '" + memberName + "' member found in what was expected to be an interface wrapper");
-        return elem;
+  private Type typeForName(final JsonElement typeElem) {
+    try {
+      return Class.forName("org.vitrivr.cthulhu.jobs." + typeElem.getAsString());
+    } catch (ClassNotFoundException e) {
+      throw new JsonParseException(e);
     }
+  }
+
+  private JsonElement get(final JsonObject wrapper, String memberName) {
+    final JsonElement elem = wrapper.get(memberName);
+    if (elem == null) {
+      throw new JsonParseException(
+          "no '" + memberName + "' member found in what was expected to be an interface wrapper");
+    }
+    return elem;
+  }
 }

--- a/src/org/vitrivr/cthulhu/jobs/JobFactory.java
+++ b/src/org/vitrivr/cthulhu/jobs/JobFactory.java
@@ -1,61 +1,66 @@
 package org.vitrivr.cthulhu.jobs;
 
-import org.vitrivr.cthulhu.jobs.BashJob;
-import com.google.gson.GsonBuilder;
 import com.google.gson.Gson;
-
-import java.util.List;
-import java.util.ArrayList;
-
-import java.lang.reflect.Type;
+import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
 
 public class JobFactory {
-    private Gson gson;
-    private JobTools tools = null;
 
-    /**
-     * Builds a job based on a description received in a JSON-formatted string.
-     * <p>
-     *
-     * Builds a job based on a JSON-formatted description. The job type must be present,
-     * or it defaults to bash. Existing job types are:
-     * * Bash script "BashJob"
-     * * Feature extraction "FeatureExtractionJob"
-     *
-     * @param description The JSON definition of the job. It requires job type, action, name, status, and priority.
-     * @return A Job object created using the JSON definition. If the definition is wrong, an exception will be thrown.
-     */
-    public Job buildJob(String description) {
-        Job jb = gson.fromJson(description,Job.class);
-        if(tools != null) jb.setTools(tools);
-        return jb;
+  private Gson gson;
+  private JobTools tools = null;
+
+  public JobFactory() {
+    this.gson = new GsonBuilder()
+        .registerTypeAdapter(Job.class, new JobAdapter())
+        .create();
+  }
+
+  /**
+   * Builds a job based on a description received in a JSON-formatted string.
+   * <p>
+   *
+   * Builds a job based on a JSON-formatted description. The job type must be present, or it
+   * defaults to bash. Existing job types are: * Bash script "BashJob" * Feature extraction
+   * "FeatureExtractionJob"
+   *
+   * @param description The JSON definition of the job. It requires job type, action, name,
+   *     status, and priority.
+   * @return A Job object created using the JSON definition. If the definition is wrong, an
+   *     exception will be thrown.
+   */
+  public Job buildJob(String description) {
+    Job jb = gson.fromJson(description, Job.class);
+    if (tools != null) {
+      jb.setTools(tools);
     }
-    public Job buildJob(String description, String type, int priority) {
-        Job jb = null;
-        switch (type) {
-        case "BashJob":
-            jb = new BashJob(description,priority);
-            break;
-        default:
-            throw new IllegalArgumentException("Invalid job type: "+type);
-        }
-        if(tools != null) jb.setTools(tools);
-        return jb;
+    return jb;
+  }
+
+  public Job buildJob(String description, String type, int priority) {
+    if (!"BashJob".equals(type)) {
+      throw new IllegalArgumentException("Invalid job type: " + type);
     }
-    public List<Job> buildJobs(String description) {
-        Type listType = new TypeToken<ArrayList<Job>>(){}.getType();
-        List<Job> jobs = gson.fromJson(description,listType);
-        if(tools != null) jobs.stream().forEach(j-> j.setTools(tools));
-        return jobs;
+    Job jb = new BashJob(description, priority);
+    if (tools != null) {
+      jb.setTools(tools);
     }
-    public void setTools(JobTools tools) {
-        this.tools = tools;
+    return jb;
+  }
+
+  public List<Job> buildJobs(String description) {
+    Type listType = new TypeToken<ArrayList<Job>>() {
+    }.getType();
+    List<Job> jobs = gson.fromJson(description, listType);
+    if (tools != null) {
+      jobs.forEach(j -> j.setTools(tools));
     }
-    public JobFactory() {
-        Gson gson = new GsonBuilder()
-            .registerTypeAdapter(Job.class, new JobAdapter())
-            .create();
-        this.gson = gson;
-    }
+    return jobs;
+  }
+
+  public void setTools(JobTools tools) {
+    this.tools = tools;
+  }
 }

--- a/src/org/vitrivr/cthulhu/jobs/JobQueue.java
+++ b/src/org/vitrivr/cthulhu/jobs/JobQueue.java
@@ -3,12 +3,26 @@ package org.vitrivr.cthulhu.jobs;
 import java.util.PriorityQueue;
 
 public class JobQueue {
-    private PriorityQueue<Job> pq;
-    public JobQueue() {
-        pq = new PriorityQueue<Job>();
-    }
-    public void push(Job j) { pq.add(j); }
-    public Job pop() { return pq.poll(); }
-    public Job peek() { return pq.peek(); }
-    public int size() { return pq.size(); }
+
+  private PriorityQueue<Job> pq;
+
+  public JobQueue() {
+    pq = new PriorityQueue<>();
+  }
+
+  public void push(Job j) {
+    pq.add(j);
+  }
+
+  public Job pop() {
+    return pq.poll();
+  }
+
+  public Job peek() {
+    return pq.peek();
+  }
+
+  public int size() {
+    return pq.size();
+  }
 }

--- a/src/org/vitrivr/cthulhu/jobs/JobTools.java
+++ b/src/org/vitrivr/cthulhu/jobs/JobTools.java
@@ -1,99 +1,104 @@
 package org.vitrivr.cthulhu.jobs;
 
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.util.Properties;
-
-import org.vitrivr.cthulhu.jobs.util.Zipper;
-import org.vitrivr.cthulhu.rest.CthulhuRESTConnector;
-
-import org.vitrivr.cthulhu.worker.Worker;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-
-import java.io.File;
-import java.io.IOException;
-import java.io.FileNotFoundException;
-import java.net.URL;
-import java.lang.ClassLoader;
+import org.vitrivr.cthulhu.jobs.util.Zipper;
+import org.vitrivr.cthulhu.rest.CthulhuRESTConnector;
+import org.vitrivr.cthulhu.worker.Worker;
 
 public class JobTools {
-    CthulhuRESTConnector conn;
-    Properties props;
-    Worker coord;
-    Logger lg = LogManager.getLogger("r.job.tools");
 
-    public JobTools(Properties props, CthulhuRESTConnector conn) {
-        this.props = props;
-        this.conn = conn;
-    }
-    public JobTools(Properties props, CthulhuRESTConnector conn, Worker coord) {
-        this(props,conn);
-        this.coord = coord;
-    }
-    public String getCineastLocation() {
-        return props.getProperty("cineast_dir");
-    }
-    public String getJavaFlags() {
-        return props.getProperty("cineast_java_flags","");
-    }
-    public boolean delete(File f) throws IOException {
-        if (f.isDirectory()) {
-            for (File c : f.listFiles())
-                delete(c);
-        }
-        if (!f.delete())
-            throw new FileNotFoundException("Failed to delete file: " + f);
-        return true;
-    }
-    public void sendZipDirectory(String directory, String file_name) throws Exception {
-        File fsDir = new File(directory);
-        lg.info("Sending directory {} to host {} as file {}",
-                directory, coord.getId(), file_name);
-        conn.sendStream(fsDir, Zipper::zip, coord, file_name);
-    }
-    public boolean getFile(String filename, String workingDir) {
-        File wdFl = new File(workingDir);
-        File prseFname = new File(filename);
-        File localFile = new File(wdFl, prseFname.getName());
-        if(localFile.exists()) {
-            // We have a problem: The file exists. What do we do?
-            return true;
-        }
-        try {
-            conn.getFile(coord, "/data/"+filename, localFile);
-        } catch (Exception e) {
-            lg.error("Trouble getting file {}. Exception: {}",
-                     filename, e.toString());
-            return false; // Error
-        }
-        return true;
-    }
-    public String setWorkingDirectory(Job j) {
-        String workspaceDir = props.getProperty("workspace");
-        File wsd = new File(workspaceDir);
+  private CthulhuRESTConnector conn;
+  Properties props;
+  private Worker coord;
+  Logger lg = LogManager.getLogger("r.job.tools");
 
-        File dir = null;
-        int tryCount = 0;
-        String suffix = "";
-        String fName = null;
-        boolean created = false;
-        while (dir == null || tryCount < 10) {
-            fName = workspaceDir + "/" + j.getName() + suffix;
-            dir = new File(fName);
-            try {
-                created = dir.mkdir();
-            } catch (Exception e) {
-                lg.error("Error when trying to create a working directory for {}. Exception: {}",
-                         j.getName(), e.toString());
-            }
-            if(created == true) break;
-            tryCount += 1;
-            suffix = Integer.toString(tryCount);
-        }
-        if(dir == null || created == false) {
-            lg.error("Error when trying to create working directory {}.", fName);
-            return null; // ERROR
-        }
-        return fName;
+  public JobTools(Properties props, CthulhuRESTConnector conn) {
+    this.props = props;
+    this.conn = conn;
+  }
+
+  public JobTools(Properties props, CthulhuRESTConnector conn, Worker coord) {
+    this(props, conn);
+    this.coord = coord;
+  }
+
+  public String getCineastLocation() {
+    return props.getProperty("cineast_dir");
+  }
+
+  public String getJavaFlags() {
+    return props.getProperty("cineast_java_flags", "");
+  }
+
+  public boolean delete(File f) throws IOException {
+    if (f.isDirectory()) {
+      for (File c : f.listFiles()) {
+        delete(c);
+      }
     }
+    if (!f.delete()) {
+      throw new FileNotFoundException("Failed to delete file: " + f);
+    }
+    return true;
+  }
+
+  public void sendZipDirectory(String directory, String file_name) throws Exception {
+    File fsDir = new File(directory);
+    lg.info("Sending directory {} to host {} as file {}",
+            directory, coord.getId(), file_name);
+    conn.sendStream(fsDir, Zipper::zip, coord, file_name);
+  }
+
+  public boolean getFile(String filename, String workingDir) {
+    File wdFl = new File(workingDir);
+    File prseFname = new File(filename);
+    File localFile = new File(wdFl, prseFname.getName());
+    if (localFile.exists()) {
+      // We have a problem: The file exists. What do we do?
+      return true;
+    }
+    try {
+      conn.getFile(coord, "/data/" + filename, localFile);
+    } catch (Exception e) {
+      lg.error("Trouble getting file {}. Exception: {}",
+               filename, e.toString());
+      return false; // Error
+    }
+    return true;
+  }
+
+  public String setWorkingDirectory(Job j) {
+    String workspaceDir = props.getProperty("workspace");
+
+    File dir = null;
+    int tryCount = 0;
+    String suffix = "";
+    String fName = null;
+    boolean created = false;
+    while (dir == null || tryCount < 10) {
+      fName = workspaceDir + "/" + j.getName() + suffix;
+      dir = new File(fName);
+      try {
+        created = dir.mkdir();
+      } catch (Exception e) {
+        lg.error("Error when trying to create a working directory for {}. Exception: {}",
+                 j.getName(), e.toString());
+      }
+      if (created) {
+        break;
+      }
+      tryCount += 1;
+      suffix = Integer.toString(tryCount);
+    }
+    if (!created) {
+      lg.error("Error when trying to create working directory {}.", fName);
+      return null; // ERROR
+    }
+    return fName;
+  }
 }

--- a/src/org/vitrivr/cthulhu/jobs/util/StreamUtils.java
+++ b/src/org/vitrivr/cthulhu/jobs/util/StreamUtils.java
@@ -1,60 +1,54 @@
 package org.vitrivr.cthulhu.jobs.util;
 
 import java.io.File;
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
-
-import java.nio.channels.ReadableByteChannel;
-import java.nio.channels.WritableByteChannel;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
-
-import java.io.IOException;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.WritableByteChannel;
 
 public class StreamUtils {
-    public static long stream(InputStream input, OutputStream output) throws IOException {
-        try (
-             ReadableByteChannel inputChannel = Channels.newChannel(input);
-             WritableByteChannel outputChannel = Channels.newChannel(output);
-             ) {
-                ByteBuffer buffer = ByteBuffer.allocateDirect(10240);
-                long size = 0;
-                while (inputChannel.read(buffer) != -1) {
-                    buffer.flip();
-                    size += outputChannel.write(buffer);
-                    buffer.clear();
-                }
-                return size;
-            }
-    }
-    public static void copy(InputStream in, OutputStream out) throws IOException {
-        byte[] buffer = new byte[1024];
-        while (true) {
-            int readCount = in.read(buffer);
-            if (readCount < 0) {
-                break;
-            }
-            out.write(buffer, 0, readCount);
-        }
-    }
 
-    public static void copy(File file, OutputStream out) throws IOException {
-        InputStream in = new FileInputStream(file);
-        try {
-            copy(in, out);
-        } finally {
-            in.close();
-        }
+  public static long stream(InputStream input, OutputStream output) throws IOException {
+    try (
+        ReadableByteChannel inputChannel = Channels.newChannel(input);
+        WritableByteChannel outputChannel = Channels.newChannel(output);
+    ) {
+      ByteBuffer buffer = ByteBuffer.allocateDirect(10240);
+      long size = 0;
+      while (inputChannel.read(buffer) != -1) {
+        buffer.flip();
+        size += outputChannel.write(buffer);
+        buffer.clear();
+      }
+      return size;
     }
+  }
 
-    public static void copy(InputStream in, File file) throws IOException {
-        OutputStream out = new FileOutputStream(file);
-        try {
-            copy(in, out);
-        } finally {
-            out.close();
-        }
+  public static void copy(InputStream in, OutputStream out) throws IOException {
+    byte[] buffer = new byte[1024];
+    while (true) {
+      int readCount = in.read(buffer);
+      if (readCount < 0) {
+        break;
+      }
+      out.write(buffer, 0, readCount);
     }
+  }
+
+  public static void copy(File file, OutputStream out) throws IOException {
+    try (InputStream in = new FileInputStream(file)) {
+      copy(in, out);
+    }
+  }
+
+  public static void copy(InputStream in, File file) throws IOException {
+    try (OutputStream out = new FileOutputStream(file)) {
+      copy(in, out);
+    }
+  }
 }

--- a/src/org/vitrivr/cthulhu/jobs/util/Zipper.java
+++ b/src/org/vitrivr/cthulhu/jobs/util/Zipper.java
@@ -1,50 +1,40 @@
 package org.vitrivr.cthulhu.jobs.util;
 
-import java.util.zip.ZipOutputStream;
-import java.util.zip.ZipEntry;
-
-import java.io.OutputStream;
 import java.io.File;
-import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.UncheckedIOException;
-
-import java.util.LinkedList;
-import java.util.Deque;
-
 import java.net.URI;
+import java.util.Deque;
+import java.util.LinkedList;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 public class Zipper {
-    public static boolean zip(File directory, OutputStream zipOutput) {
-        URI base = directory.toURI();
-        Deque<File> queue = new LinkedList<File>();
-        queue.push(directory);
-        boolean success = true;
-        try {
-            ZipOutputStream zout = new ZipOutputStream(zipOutput);
-            while (!queue.isEmpty()) {
-                directory = queue.pop();
-                for (File kid : directory.listFiles()) {
-                    String name = base.relativize(kid.toURI()).getPath();
-                    if (kid.isDirectory()) {
-                        queue.push(kid);
-                        name = name.endsWith("/") ? name : name + "/";
-                        zout.putNextEntry(new ZipEntry(name));
-                    } else {
-                        zout.putNextEntry(new ZipEntry(name));
-                        StreamUtils.copy(kid, zout);
-                        zout.closeEntry();
-                    }
-                }
-            }
-            zout.finish();
-        } catch (Exception e) {
-            success = false;
-        } finally {
-            return success;
+
+  public static boolean zip(File directory, OutputStream zipOutput) {
+    URI base = directory.toURI();
+    Deque<File> queue = new LinkedList<>();
+    queue.push(directory);
+    try {
+      ZipOutputStream zout = new ZipOutputStream(zipOutput);
+      while (!queue.isEmpty()) {
+        directory = queue.pop();
+        for (File kid : directory.listFiles()) {
+          String name = base.relativize(kid.toURI()).getPath();
+          if (kid.isDirectory()) {
+            queue.push(kid);
+            name = name.endsWith("/") ? name : name + "/";
+            zout.putNextEntry(new ZipEntry(name));
+          } else {
+            zout.putNextEntry(new ZipEntry(name));
+            StreamUtils.copy(kid, zout);
+            zout.closeEntry();
+          }
         }
+      }
+      zout.finish();
+    } catch (Exception e) {
+      return false;
     }
+    return true;
+  }
 }

--- a/src/org/vitrivr/cthulhu/keeper/JsonKeeper.java
+++ b/src/org/vitrivr/cthulhu/keeper/JsonKeeper.java
@@ -1,31 +1,35 @@
 package org.vitrivr.cthulhu.keeper;
 
-import org.vitrivr.cthulhu.scheduler.CthulhuScheduler;
+import static org.apache.logging.log4j.LogManager.getLogger;
 
-import com.google.gson.GsonBuilder;
 import com.google.gson.Gson;
-
-import java.util.Properties;
-
 import java.io.FileWriter;
 import java.io.IOException;
+import java.util.Properties;
+import org.apache.logging.log4j.Logger;
+import org.vitrivr.cthulhu.scheduler.CthulhuScheduler;
 
 public class JsonKeeper implements StatusKeeper {
-    private Gson gson;
-    private Properties prop;
-    private String outFile;
-    public JsonKeeper(Properties prop) {
-        this.prop = prop;
-        outFile = prop != null ? prop.getProperty("statusFile",".cthulhuStatus.json") : ".cthulhuStatus.json";
-        gson = new Gson();
+
+  Logger logger = getLogger(JsonKeeper.class);
+  private Gson gson;
+  private String outFile;
+
+  public JsonKeeper(Properties prop) {
+    outFile = prop != null ? prop.getProperty("statusFile", ".cthulhuStatus.json")
+        : ".cthulhuStatus.json";
+    gson = new Gson();
+  }
+
+  public void saveStatus(CthulhuScheduler cs) {
+    try (FileWriter writer = new FileWriter(outFile)) {
+      gson.toJson(cs, writer);
+    } catch (IOException e) {
+      logger.error("Failed to save status", e);
     }
-    public void saveStatus(CthulhuScheduler cs) {
-        try (FileWriter writer = new FileWriter(outFile)) {
-                gson.toJson(cs, writer);
-            } catch (IOException e) {
-            /* Ignoring */
-        } catch (Exception e) {
-        }
-    }
-    public String getOutFile() { return outFile; }
+  }
+
+  public String getOutFile() {
+    return outFile;
+  }
 }

--- a/src/org/vitrivr/cthulhu/keeper/StatusKeeper.java
+++ b/src/org/vitrivr/cthulhu/keeper/StatusKeeper.java
@@ -3,9 +3,10 @@ package org.vitrivr.cthulhu.keeper;
 import org.vitrivr.cthulhu.scheduler.CthulhuScheduler;
 
 public interface StatusKeeper {
-    /**
-     * Serializes the status of the CthulhuScheduler object. It saves Job table, Worker table, and
-     * runtime properties to persistent storage.
-     */
-    public void saveStatus(CthulhuScheduler cs);
+
+  /**
+   * Serializes the status of the CthulhuScheduler object. It saves Job table, Worker table, and
+   * runtime properties to persistent storage.
+   */
+  public void saveStatus(CthulhuScheduler cs);
 }

--- a/src/org/vitrivr/cthulhu/rest/CthulhuREST.java
+++ b/src/org/vitrivr/cthulhu/rest/CthulhuREST.java
@@ -1,175 +1,189 @@
 package org.vitrivr.cthulhu.rest;
 
-import org.vitrivr.cthulhu.scheduler.CthulhuScheduler;
-
-import org.vitrivr.cthulhu.jobs.util.StreamUtils;
-
-import static spark.Spark.*;
-
-import javax.servlet.MultipartConfigElement;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import static spark.Spark.delete;
+import static spark.Spark.get;
+import static spark.Spark.port;
+import static spark.Spark.post;
+import static spark.Spark.put;
+import static spark.Spark.staticFileLocation;
+import static spark.Spark.stop;
 
 import com.google.gson.Gson;
-
 import java.io.File;
-import java.io.IOException;
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.FileNotFoundException;
-
 import java.util.Properties;
-
+import javax.servlet.MultipartConfigElement;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.vitrivr.cthulhu.jobs.Job;
+import org.vitrivr.cthulhu.jobs.util.StreamUtils;
+import org.vitrivr.cthulhu.scheduler.CthulhuScheduler;
 import org.vitrivr.cthulhu.worker.Worker;
 
 public class CthulhuREST {
-    private String workspace;
-    private CthulhuScheduler ms;
-    private Logger LOGGER = LogManager.getLogger("r.m.api");
-    /**
-     * A gson instance to convert to JSON and to Job objects (or others) when exchanging data with another host.
-     */
-    private Gson gson;
-    private int port;
-    /**
-     * Initializes all the REST services for this agent (worker/coordinator)
-     * <p>
-     * If no port can be determined to listen on, an exception will be thrown
-     *
-     * @param ms This is the scheduler that is in charge of managing microservice REST calls
-     * @param prop This is a properties object with all runtime properties of the agent (worker/coord)
-     */
-    public void init(CthulhuScheduler ms, Properties prop) throws Exception {
-        this.ms = ms;
-        gson = new Gson();
-        LOGGER.info("Creating REST paths");
-        String sf = prop.getProperty("staticfiles");
-        workspace = prop.getProperty("workspace");
-        try {
-            port = Integer.parseInt(prop.getProperty("port"));
-        } catch (Exception e) { throw e; }
-        setupRESTCalls(sf,port);
-        LOGGER.info("Ready!");
-    }
 
-    /**
-     * Stops the REST service.
-     * <p>
-     * Stops the Jetty server that is in charge of running the REST service.
-     */
-    public void stopServer() {
-        stop();
-    }
+  private String workspace;
+  private CthulhuScheduler ms;
+  private Logger LOGGER = LogManager.getLogger("r.m.api");
+  /**
+   * A gson instance to convert to JSON and to Job objects (or others) when exchanging data with
+   * another host.
+   */
+  private Gson gson;
 
-    public void setupRESTCalls(String staticFilesDir, int listenPort) {
-        port(listenPort);
-        LOGGER.info("Static files are served from: "+staticFilesDir);
-        staticFileLocation(staticFilesDir);
-        get("/data/*", (req, res) -> {
-                String fname = req.pathInfo().replaceFirst("/data/", "");
-                fname = fname.replace("../", "/");
-                InputStream is;
-                try {
-                    File infile = new File(workspace, fname);
-                    is = new FileInputStream(infile);
-                    if (is != null) {
-                        //res.type(getContentType(fname));
-                        res.status(200);
+  /**
+   * Initializes all the REST services for this agent (worker/coordinator)
+   * <p>
+   * If no port can be determined to listen on, an exception will be thrown
+   *
+   * @param ms This is the scheduler that is in charge of managing microservice REST calls
+   * @param prop This is a properties object with all runtime properties of the agent
+   *     (worker/coord)
+   */
+  public void init(CthulhuScheduler ms, Properties prop) {
+    this.ms = ms;
+    gson = new Gson();
+    LOGGER.info("Creating REST paths");
+    String sf = prop.getProperty("staticfiles");
+    workspace = prop.getProperty("workspace");
+    int port = Integer.parseInt(prop.getProperty("port"));
+    setupRESTCalls(sf, port);
+    LOGGER.info("Ready!");
+  }
 
-                        byte[] buf = new byte[1024];
-                        OutputStream os = res.raw().getOutputStream();
-                        int count = 0;
-                        while ((count = is.read(buf)) >= 0) {
-                            os.write(buf, 0, count);
-                        }
-                        is.close();
-                        os.close();
-                    }
-                } catch (FileNotFoundException e) {
-                    e.printStackTrace();
-                    return null;
-                } catch (IOException e) {
-                    e.printStackTrace();
-                    return null;
-                }
-                return "";
-            });
-        get("/jobs/:id", (req, res) -> {
-                String id = req.params(":id");
-                if(id.isEmpty()) res.status(400);
-                return gson.toJson(ms.getJobs(id));
-            });
-        get("/jobs", (req, res) -> gson.toJson(ms.getJobs()) );
-        get("/workers/:id", (req, res) -> {
-                String id = req.params(":id");
-                if(id.isEmpty()) res.status(400);
-                return gson.toJson(ms.getWorkers(id));
-            });
-        get("/workers", (req, res) -> gson.toJson(ms.getWorkers()) );
-        post("/data/*", (req, res) -> {
-                String fname = req.pathInfo().replaceFirst("/data/", "");
-                fname = fname.replace("../", "/");
-                System.out.println("Receiving a file back: "+fname);
-                File fout = new File(workspace, fname);
-                if(fout.exists()) {
-                    System.out.println("File exists. Not saving");
-                    res.status(400);
-                    //return "";
-                }
-                req.attribute("org.eclipse.jetty.multipartConfig", new MultipartConfigElement("/temp"));
-                try (InputStream is = req.raw().getPart("file").getInputStream()) {
-                        // Use the input stream to create a file
-                        FileOutputStream fos = new FileOutputStream(fout);
-                        StreamUtils.copy(is, fos);
-                    }
-                return "";
-            });
-        post("/jobs", (req, res) -> {
-                Job j = ms.registerJob(req.body());
-                if(j == null) res.status(400);
-                return "";
-            });
-        post("/workers", (req, res) -> {
-                String address = req.queryParams("address");
-                int port = Integer.parseInt(req.queryParams("port"));
-                String ip = req.ip();
-                if(address == null || address.isEmpty()) address = ip;
-                int st = ms.registerWorker(address, port);
-                if(st != 0) res.status(400);
-                return "";
-            });
+  /**
+   * Stops the REST service.
+   * <p>
+   * Stops the Jetty server that is in charge of running the REST service.
+   */
+  public void stopServer() {
+    stop();
+  }
 
-        delete("/jobs/:id", (req, res) -> {
-                String id = req.params(":id");
-                boolean force = false;
-                if(req.queryParams("force") != null) force = Boolean.parseBoolean(req.queryParams("force"));
-                else if(req.params("force") != null) force = Boolean.parseBoolean(req.params("force"));
-                Job job;
-                try {
-                    job = ms.deleteJob(id,force);
-                } catch (Exception e) {
-                    res.status(400);
-                    return e.getMessage();
-                }
-                if(job == null) res.status(400);
-                return "";
-            });
-        delete("/workers/:id", (req, res) -> {
-                String id = req.params(":id");
-                Worker worker = ms.deleteWorker(id);
-                if(worker == null) res.status(400);
-                return "";
-            });
-        put("/jobs",(req,res) -> {
-                Job old = ms.updateJob(req.body());
-                if(old == null) res.status(400);
-                return "";
-            });
-    }
+  public void setupRESTCalls(String staticFilesDir, int listenPort) {
+    port(listenPort);
+    LOGGER.info("Static files are served from: " + staticFilesDir);
+    staticFileLocation(staticFilesDir);
+    get("/data/*", (req, res) -> {
+      String fname = req.pathInfo().replaceFirst("/data/", "");
+      fname = fname.replace("../", "/");
+      InputStream is;
+      try {
+        File infile = new File(workspace, fname);
+        is = new FileInputStream(infile);
+        if (is != null) {
+          //res.type(getContentType(fname));
+          res.status(200);
+
+          byte[] buf = new byte[1024];
+          OutputStream os = res.raw().getOutputStream();
+          int count = 0;
+          while ((count = is.read(buf)) >= 0) {
+            os.write(buf, 0, count);
+          }
+          is.close();
+          os.close();
+        }
+      } catch (IOException e) {
+        e.printStackTrace();
+        return null;
+      }
+      return "";
+    });
+    get("/jobs/:id", (req, res) -> {
+      String id = req.params(":id");
+      if (id.isEmpty()) {
+        res.status(400);
+      }
+      return gson.toJson(ms.getJobs(id));
+    });
+    get("/jobs", (req, res) -> gson.toJson(ms.getJobs()));
+    get("/workers/:id", (req, res) -> {
+      String id = req.params(":id");
+      if (id.isEmpty()) {
+        res.status(400);
+      }
+      return gson.toJson(ms.getWorkers(id));
+    });
+    get("/workers", (req, res) -> gson.toJson(ms.getWorkers()));
+    post("/data/*", (req, res) -> {
+      String fname = req.pathInfo().replaceFirst("/data/", "");
+      fname = fname.replace("../", "/");
+      System.out.println("Receiving a file back: " + fname);
+      File fout = new File(workspace, fname);
+      if (fout.exists()) {
+        System.out.println("File exists. Not saving");
+        res.status(400);
+        //return "";
+      }
+      req.attribute("org.eclipse.jetty.multipartConfig", new MultipartConfigElement("/temp"));
+      try (InputStream is = req.raw().getPart("file").getInputStream()) {
+        // Use the input stream to create a file
+        FileOutputStream fos = new FileOutputStream(fout);
+        StreamUtils.copy(is, fos);
+      }
+      return "";
+    });
+    post("/jobs", (req, res) -> {
+      Job j = ms.registerJob(req.body());
+      if (j == null) {
+        res.status(400);
+      }
+      return "";
+    });
+    post("/workers", (req, res) -> {
+      String address = req.queryParams("address");
+      int port = Integer.parseInt(req.queryParams("port"));
+      String ip = req.ip();
+      if (address == null || address.isEmpty()) {
+        address = ip;
+      }
+      int st = ms.registerWorker(address, port);
+      if (st != 0) {
+        res.status(400);
+      }
+      return "";
+    });
+
+    delete("/jobs/:id", (req, res) -> {
+      String id = req.params(":id");
+      boolean force = false;
+      if (req.queryParams("force") != null) {
+        force = Boolean.parseBoolean(req.queryParams("force"));
+      } else if (req.params("force") != null) {
+        force = Boolean.parseBoolean(req.params("force"));
+      }
+      Job job;
+      try {
+        job = ms.deleteJob(id, force);
+      } catch (Exception e) {
+        res.status(400);
+        return e.getMessage();
+      }
+      if (job == null) {
+        res.status(400);
+      }
+      return "";
+    });
+    delete("/workers/:id", (req, res) -> {
+      String id = req.params(":id");
+      Worker worker = ms.deleteWorker(id);
+      if (worker == null) {
+        res.status(400);
+      }
+      return "";
+    });
+    put("/jobs", (req, res) -> {
+      Job old = ms.updateJob(req.body());
+      if (old == null) {
+        res.status(400);
+      }
+      return "";
+    });
+  }
 }

--- a/src/org/vitrivr/cthulhu/rest/CthulhuRESTConnector.java
+++ b/src/org/vitrivr/cthulhu/rest/CthulhuRESTConnector.java
@@ -1,198 +1,198 @@
 package org.vitrivr.cthulhu.rest;
 
+import com.google.gson.Gson;
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.function.BiPredicate;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
 import org.vitrivr.cthulhu.jobs.Job;
 import org.vitrivr.cthulhu.worker.Worker;
 
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.net.MalformedURLException;
-
-import java.util.function.BiPredicate;
-
-import java.io.IOException;
-import java.io.OutputStream;
-import java.io.InputStream;
-import java.io.BufferedInputStream;
-import java.io.File;
-import java.io.PrintWriter;
-import java.io.OutputStreamWriter;
-import java.nio.charset.StandardCharsets;
-
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
-import com.google.gson.Gson;
-
 /**
  * @author Pablo E. <mail (at) iampablo.me>
- * 
  */
 public class CthulhuRESTConnector {
-    /**
-     * Protocol to be used when contacting to another host.
-     */
-    final String PROTOCOL = "http";
-    /**
-     * A gson instance to convert to JSON and to Job objects (or others) when exchanging data with another host.
-     */
-    Gson gson;
-    public CthulhuRESTConnector() {
-        gson = new Gson();
-    }
-    /**
-     * Private method that realizes a request to a different host. The method takes in the host it shall communicate with,
-     * the method to use ("POST","GET",..), the path ("/jobs",..) and the body contents.
-     * <p>
-     * If the host returns any text in the body of the response, this methor will return that text.
-     * If an error occurs when communicating with the host, an exception will be thrown. 
-     *
-     * @param method The method to use when realizing an http/https connection (POST,GET,PUT,DELETE)
-     * @param path The path to access (/jobs, /jobs/jobName, /workers, etc.)
-     * @param body The data to add in the body of the request (a Job's JSON definition, force parameter, etc)
-     * @return The text returned by the remote host
-     */
-    String makeRequest(Worker w, String method, String path, String body) throws Exception {
-        String resBody;
-        try {
-            URL workerUrl = new URL(PROTOCOL, w.getAddress(), w.getPort(), path);
-            HttpURLConnection con = (HttpURLConnection) workerUrl.openConnection();
-            con.setDoOutput(true);
-            con.setChunkedStreamingMode(0);
-            con.setRequestProperty("charset", "utf-8");
-            con.setRequestMethod(method);
-            if(body != null && !body.isEmpty()) {
-                byte[] reqData = body.getBytes(StandardCharsets.UTF_8);
-                int contLength = reqData.length;
-                con.setRequestProperty("Content-Length", Integer.toString(contLength));
-                OutputStream os = con.getOutputStream();
-                os.write(reqData);
-                os.flush();
-            }
-            InputStream in = new BufferedInputStream(con.getInputStream());
-            resBody = IOUtils.toString(in, "UTF-8"); 
 
-            if (con.getResponseCode() != HttpURLConnection.HTTP_CREATED &&
-                con.getResponseCode() != HttpURLConnection.HTTP_OK) {
-                throw new RuntimeException("Failed : HTTP error code : "
-                                           + con.getResponseCode());
-            }
-            con.disconnect();
-        } catch (Exception e) {
-            throw e;
-        }
-        return resBody;
-    }
-    /**
-     * Realizes a 'GET' request for all jobs in the remote host.
-     * <p>
-     * Returns the json definition of a list of jobs. If an error occurs, an exception 
-     * will be thrown. Internally it uses the {@link #makeRequest(Worker, String, String, String) makeRequest} method.
-     *
-     * @param w The object describing the remote host to communicate with.
-     * @return The JSON definition of a list of jobs. An empty list if there are no jobs.
-     */
-    public String getJobs(Worker w) throws Exception {
-        String res = makeRequest(w, "GET","/jobs","");
-        return res;
-    }
-    /**
-     * Realizes a 'POST' request to send a job to a remote host.
-     * <p>
-     * If an error occurs, an exception will be thrown. Internally it uses the {@link #makeRequest(Worker, String, String, String) makeRequest} method.
-     *
-     * @param w The object describing the remote host to communicate with.
-     * @param j The job to send to the remote host
-     */
-    public void postJob(Job j, Worker w) throws Exception {
-        makeRequest(w,"POST", "/jobs",gson.toJson(j));
-    }
-    /**
-     * Realizes a 'PUT' request to update a job in a remote host.
-     * <p>
-     * If an error occurs, an exception will be thrown. Internally it uses the {@link #makeRequest(Worker, String, String, String) makeRequest} method.
-     *
-     * @param w The object describing the remote host to communicate with.
-     * @param j The job to put to the remote host
-     */
-    public void putJob(Job j, Worker w) throws Exception {
-        makeRequest(w,"PUT", "/jobs",gson.toJson(j));
-    }
-    /**
-     * Realizes a 'DELETE' request to delete a job in a remote host
-     * <p>
-     * If force is `false`, and the job is running, an exception will be thrown.
-     * If force is `true` and the job is running, it will be stopped and removed completely.
-     * If any errors occur, a exception will be thrown.
-     * Internally it uses the {@link #makeRequest(Worker, String, String, String) makeRequest} method.
-     *
-     * @param w The object describing the remote host to communicate with.
-     * @param j The job to delete in the remote host
-     */
-    public void deleteJob(Job j, Worker w, boolean force) throws Exception {
-        String forceStr = force ? "TRUE" : "FALSE";
-        makeRequest(w,"DELETE", "/jobs/"+j.getName(),"force="+forceStr);
-    }
-    /**
-     * Realizes a 'POST' request to register a worker to a remote host.
-     * <p>
-     * This is normally called by a WORKER to inform a COORDINATOR that it is online and ready to work.
-     * If an error occurs, an exception will be thrown. Internally it uses the {@link #makeRequest(Worker, String, String, String) makeRequest} method.
-     *
-     * @param w The object describing the remote host to communicate with.
-     * @param j The job to send to the remote host
-     */
-    public void postWorker(Worker coordinator,
-                           String workerAddress, int workerPort)  throws Exception {
-            String input = "address="+workerAddress+"&port="+workerPort;
-            makeRequest(coordinator, "POST", "/workers", input);
-    }
+  /**
+   * Protocol to be used when contacting to another host.
+   */
+  private final String PROTOCOL = "http";
+  /**
+   * A gson instance to convert to JSON and to Job objects (or others) when exchanging data with
+   * another host.
+   */
+  private Gson gson;
 
-    public InputStream getFile(Worker host, String remoteFile, File localFile) throws Exception {
-        InputStream in = null;
-        try {
-            URL workerUrl = new URL(PROTOCOL, host.getAddress(), host.getPort(), remoteFile);
-            FileUtils.copyURLToFile(workerUrl, localFile);
-        } catch (IOException io) {
-            throw io;
-        }
-        return in;
+  public CthulhuRESTConnector() {
+    gson = new Gson();
+  }
+
+  /**
+   * Private method that realizes a request to a different host. The method takes in the host it
+   * shall communicate with, the method to use ("POST","GET",..), the path ("/jobs",..) and the body
+   * contents.
+   * <p>
+   * If the host returns any text in the body of the response, this methor will return that text. If
+   * an error occurs when communicating with the host, an exception will be thrown.
+   *
+   * @param method The method to use when realizing an http/https connection
+   *     (POST,GET,PUT,DELETE)
+   * @param path The path to access (/jobs, /jobs/jobName, /workers, etc.)
+   * @param body The data to add in the body of the request (a Job's JSON definition, force
+   *     parameter, etc)
+   * @return The text returned by the remote host
+   */
+  private String makeRequest(Worker w, String method, String path, String body) throws IOException {
+    String resBody;
+    URL workerUrl = new URL(PROTOCOL, w.getAddress(), w.getPort(), path);
+    HttpURLConnection con = (HttpURLConnection) workerUrl.openConnection();
+    con.setDoOutput(true);
+    con.setChunkedStreamingMode(0);
+    con.setRequestProperty("charset", "utf-8");
+    con.setRequestMethod(method);
+    if (body != null && !body.isEmpty()) {
+      byte[] reqData = body.getBytes(StandardCharsets.UTF_8);
+      int contLength = reqData.length;
+      con.setRequestProperty("Content-Length", Integer.toString(contLength));
+      OutputStream os = con.getOutputStream();
+      os.write(reqData);
+      os.flush();
     }
-    public void sendStream(File sendFile, BiPredicate<File, OutputStream> callback,
-                           Worker w, String remoteFile) throws Exception {
-        String CRLF = "\r\n";
-        String boundary = "cthulhuBoundary123456789";
-        PrintWriter wr = null;
-        try {
-            URL workerUrl = new URL(PROTOCOL, w.getAddress(), w.getPort(), 
-                                    "/data/"+remoteFile);
-            HttpURLConnection con = (HttpURLConnection) workerUrl.openConnection();
-            con.setRequestProperty("Content-Type", "multipart/form-data; boundary="+boundary);
-            con.setDoOutput(true);
-            con.setDoInput(true);
-            con.setUseCaches(false);
-            con.setRequestMethod("POST");
-            OutputStream out = con.getOutputStream();
-            wr = new PrintWriter(new OutputStreamWriter(out));
-            wr.print("--"+boundary+CRLF);
-            wr.print("Content-Disposition: form-data; name=\"file\"; filename=\""+remoteFile+"\""+CRLF);
-            wr.print("Content-Type: application/octet-stream"+CRLF);
-            wr.print(CRLF);
-            wr.flush();
-            boolean res = callback.test(sendFile, out);
-            out.flush();
-            if(!res) {
-                throw new Exception("Unable to send zipped directory");
-            }
-            wr.print(CRLF);
-            wr.print("--" + boundary + "--" + CRLF);
-            wr.flush();
-            if (con.getResponseCode() != HttpURLConnection.HTTP_CREATED &&
-                con.getResponseCode() != HttpURLConnection.HTTP_OK) {
-                throw new RuntimeException("Failed : HTTP error code : "
-                                           + con.getResponseCode());
-            }
-            con.disconnect();
-        } catch (Exception e) {
-            throw e;
-        }
+    InputStream in = new BufferedInputStream(con.getInputStream());
+    resBody = IOUtils.toString(in, "UTF-8");
+
+    if (con.getResponseCode() != HttpURLConnection.HTTP_CREATED &&
+        con.getResponseCode() != HttpURLConnection.HTTP_OK) {
+      throw new RuntimeException("Failed : HTTP error code : "
+                                     + con.getResponseCode());
     }
+    con.disconnect();
+    return resBody;
+  }
+
+  /**
+   * Realizes a 'GET' request for all jobs in the remote host.
+   * <p>
+   * Returns the json definition of a list of jobs. If an error occurs, an exception will be thrown.
+   * Internally it uses the {@link #makeRequest(Worker, String, String, String) makeRequest}
+   * method.
+   *
+   * @param w The object describing the remote host to communicate with.
+   * @return The JSON definition of a list of jobs. An empty list if there are no jobs.
+   */
+  public String getJobs(Worker w) throws Exception {
+    return makeRequest(w, "GET", "/jobs", "");
+  }
+
+  /**
+   * Realizes a 'POST' request to send a job to a remote host.
+   * <p>
+   * If an error occurs, an exception will be thrown. Internally it uses the {@link
+   * #makeRequest(Worker, String, String, String) makeRequest} method.
+   *
+   * @param w The object describing the remote host to communicate with.
+   * @param j The job to send to the remote host
+   */
+  public void postJob(Job j, Worker w) throws Exception {
+    makeRequest(w, "POST", "/jobs", gson.toJson(j));
+  }
+
+  /**
+   * Realizes a 'PUT' request to update a job in a remote host.
+   * <p>
+   * If an error occurs, an exception will be thrown. Internally it uses the {@link
+   * #makeRequest(Worker, String, String, String) makeRequest} method.
+   *
+   * @param w The object describing the remote host to communicate with.
+   * @param j The job to put to the remote host
+   */
+  public void putJob(Job j, Worker w) throws Exception {
+    makeRequest(w, "PUT", "/jobs", gson.toJson(j));
+  }
+
+  /**
+   * Realizes a 'DELETE' request to delete a job in a remote host
+   * <p>
+   * If force is `false`, and the job is running, an exception will be thrown. If force is `true`
+   * and the job is running, it will be stopped and removed completely. If any errors occur, a
+   * exception will be thrown. Internally it uses the {@link #makeRequest(Worker, String, String,
+   * String) makeRequest} method.
+   *
+   * @param w The object describing the remote host to communicate with.
+   * @param j The job to delete in the remote host
+   */
+  public void deleteJob(Job j, Worker w, boolean force) throws Exception {
+    String forceStr = force ? "TRUE" : "FALSE";
+    makeRequest(w, "DELETE", "/jobs/" + j.getName(), "force=" + forceStr);
+  }
+
+  /**
+   * Realizes a 'POST' request to register a worker to a remote host.
+   * <p>
+   * This is normally called by a WORKER to inform a COORDINATOR that it is online and ready to
+   * work. If an error occurs, an exception will be thrown. Internally it uses the {@link
+   * #makeRequest(Worker, String, String, String) makeRequest} method.workerAddress
+   *
+   * @param coordinator The object describing the remote host to communicate with
+   * @param workerAddress the address of the worker
+   * @param workerPort the port the worker is communicating on
+   */
+  public void postWorker(
+      Worker coordinator,
+      String workerAddress, int workerPort) throws Exception {
+    String input = "address=" + workerAddress + "&port=" + workerPort;
+    makeRequest(coordinator, "POST", "/workers", input);
+  }
+
+  public void getFile(Worker host, String remoteFile, File localFile) throws IOException {
+    URL workerUrl = new URL(PROTOCOL, host.getAddress(), host.getPort(), remoteFile);
+    FileUtils.copyURLToFile(workerUrl, localFile);
+  }
+
+  public void sendStream(
+      File sendFile, BiPredicate<File, OutputStream> callback,
+      Worker w, String remoteFile) throws Exception {
+    String CRLF = "\r\n";
+    String boundary = "cthulhuBoundary123456789";
+    PrintWriter wr;
+    URL workerUrl = new URL(PROTOCOL, w.getAddress(), w.getPort(),
+                            "/data/" + remoteFile);
+    HttpURLConnection con = (HttpURLConnection) workerUrl.openConnection();
+    con.setRequestProperty("Content-Type", "multipart/form-data; boundary=" + boundary);
+    con.setDoOutput(true);
+    con.setDoInput(true);
+    con.setUseCaches(false);
+    con.setRequestMethod("POST");
+    OutputStream out = con.getOutputStream();
+    wr = new PrintWriter(new OutputStreamWriter(out));
+    wr.print("--" + boundary + CRLF);
+    wr.print(
+        "Content-Disposition: form-data; name=\"file\"; filename=\"" + remoteFile + "\"" + CRLF);
+    wr.print("Content-Type: application/octet-stream" + CRLF);
+    wr.print(CRLF);
+    wr.flush();
+    boolean res = callback.test(sendFile, out);
+    out.flush();
+    if (!res) {
+      throw new Exception("Unable to send zipped directory");
+    }
+    wr.print(CRLF);
+    wr.print("--" + boundary + "--" + CRLF);
+    wr.flush();
+    if (con.getResponseCode() != HttpURLConnection.HTTP_CREATED &&
+        con.getResponseCode() != HttpURLConnection.HTTP_OK) {
+      throw new RuntimeException("Failed : HTTP error code : "
+                                     + con.getResponseCode());
+    }
+    con.disconnect();
+  }
 }

--- a/src/org/vitrivr/cthulhu/runners/CthulhuRunner.java
+++ b/src/org/vitrivr/cthulhu/runners/CthulhuRunner.java
@@ -1,231 +1,260 @@
 package org.vitrivr.cthulhu.runners;
 
-import com.google.common.primitives.Bytes;
-import java.net.Inet4Address;
-import java.net.SocketException;
-import java.util.Optional;
-import org.vitrivr.cthulhu.rest.CthulhuREST;
-import org.vitrivr.cthulhu.scheduler.CthulhuScheduler;
-import org.vitrivr.cthulhu.scheduler.CoordinatorScheduler;
-import org.vitrivr.cthulhu.scheduler.SchedulerFactory;
-import org.vitrivr.cthulhu.jobs.JobAdapter;
-import org.vitrivr.cthulhu.jobs.Job;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
-import org.apache.commons.io.IOUtils;
-
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-
-import org.apache.commons.cli.Options;
-import org.apache.commons.cli.DefaultParser;
+import java.io.BufferedReader;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.util.Enumeration;
+import java.util.Optional;
+import java.util.Properties;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-
-import java.util.Properties;
-import java.io.FileInputStream;
-import java.io.InputStream;
-import java.io.IOException;
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
-
-import java.util.Enumeration;
-import java.net.NetworkInterface;
-import java.net.InetAddress;
+import org.apache.commons.io.IOUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.vitrivr.cthulhu.jobs.Job;
+import org.vitrivr.cthulhu.jobs.JobAdapter;
+import org.vitrivr.cthulhu.rest.CthulhuREST;
+import org.vitrivr.cthulhu.scheduler.CoordinatorScheduler;
+import org.vitrivr.cthulhu.scheduler.CthulhuScheduler;
+import org.vitrivr.cthulhu.scheduler.SchedulerFactory;
 
 public class CthulhuRunner {
-    private static CthulhuREST api;
-    private static CthulhuScheduler ms;
-    private static Logger LOGGER = LogManager.getLogger("r.m");
-    public enum RunnerType {
-        COORDINATOR,
-        WORKER
+
+  private static RunnerType type = RunnerType.COORDINATOR;
+  private static CthulhuREST api;
+  private static CthulhuScheduler ms;
+  private static Logger LOGGER = LogManager.getLogger("r.m");
+
+  // Returns first available non-loopback, active IP address
+  private static String getIPAddress() {
+    try {
+      Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
+      while (interfaces.hasMoreElements()) {
+        NetworkInterface iface = interfaces.nextElement();
+        // filters out 127.0.0.1 and inactive interfaces
+        if (iface.isLoopback() || !iface.isUp()) {
+          continue;
+        }
+        Optional<String> optionalAddress = pickInetAddress(iface.getInetAddresses());
+        if (optionalAddress.isPresent()) {
+          return optionalAddress.get();
+        }
+      }
+    } catch (SocketException e) {
+      throw new RuntimeException(e);
     }
-    static RunnerType type = RunnerType.COORDINATOR;
+    return "127.0.0.1"; // If no IP was found earlier, just return loopback interface
+  }
 
-    // Returns first available non-loopback, active IP address
-    static String getIPAddress() {
-        try {
-            Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
-            while (interfaces.hasMoreElements()) {
-                NetworkInterface iface = interfaces.nextElement();
-                // filters out 127.0.0.1 and inactive interfaces
-                if (iface.isLoopback() || !iface.isUp())
-                    continue;
-                Optional<String> optionalAddress = pickInetAddress(iface.getInetAddresses());
-                if (optionalAddress.isPresent()) {
-                    return optionalAddress.get();
-                }
-            }
-        } catch (SocketException e) {
-            throw new RuntimeException(e);
-        }
-        return "127.0.0.1"; // If no IP was found earlier, just return loopback interface
+  /**
+   * Receives an {@link Enumeration} of addresses and waits until one is given that is not local and
+   * is an IPv4 address.
+   *
+   * @param inetAddressEnumeration the {@link Enumeration} of addresses to search
+   * @return an address if found, otherwise return an empty optional
+   */
+  static Optional<String> pickInetAddress(Enumeration<InetAddress> inetAddressEnumeration) {
+    while (inetAddressEnumeration.hasMoreElements()) {
+      InetAddress address = inetAddressEnumeration.nextElement();
+      if (!address.isLinkLocalAddress() && address instanceof Inet4Address) {
+        return Optional.of(address.getHostAddress());
+      }
     }
+    return Optional.empty();
+  }
 
-    /**
-     * Receives an {@link Enumeration} of addresses and waits until one is given that is not local and is an IPv4 address.
-     * @param inetAddressEnumeration the {@link Enumeration} of addresses to search
-     * @return an address if found, otherwise return an empty optional
-     */
-    static Optional<String> pickInetAddress(Enumeration<InetAddress> inetAddressEnumeration) {
-        while(inetAddressEnumeration.hasMoreElements()) {
-            InetAddress address = inetAddressEnumeration.nextElement();
-            if(!address.isLinkLocalAddress() && address instanceof Inet4Address) {
-                return Optional.of(address.getHostAddress());
-            }
-        }
-        return Optional.empty();
-    }
-
-    public static CommandLine populateProperties(String[] args, Properties prop) throws Exception {
-        CommandLineParser parser = new DefaultParser();
-        Options options = new Options();
-        options.addOption("h","help",false,"Display help menu");
-        options.addOption("C","coordinator",false,"Run as coordinator");
-        options.addOption("W","worker",false,"Run as worker");
-        options.addOption("ha","hostAddress",true,"Address of coordinator host [for workers] - overrides properties file");
-        options.addOption("hp","hostPort",true,"Port of coordinator host [for workers] - overrides properties file");
-        options.addOption("c","capacity",true,"Capacity, or number of jobs that can run simultaneously [for workers]");
-        options.addOption("p","port",true,"Port in which to listen to - overrides properties file");
-        options.addOption("a","address",true,"Address of the local host (DNS? IP?) - overrides properties file");
-        options.addOption("sf","staticFiles",true,"Directory where the static files will be read from (worker)");
-        options.addOption("r","restore",true,"Restore instance from status file");
-        CommandLine line;
-        try {
-            line = parser.parse(options,args);
-        } catch (ParseException exp) {
-            line = null;
-            LOGGER.error("ERROR Parsing command line.");
-        }
-
-        if(line != null && line.hasOption("W")) {
-            LOGGER.info("Starting up as worker");
-            type = RunnerType.WORKER; // Changing the runner type
-
-            String hostAddress = null;
-            if(prop.getProperty("hostAddress") != null) hostAddress = prop.getProperty("hostAddress");
-            if(line.hasOption("ha")) hostAddress = line.getOptionValue("ha");
-            prop.setProperty("hostAddress",hostAddress);
-
-            String hostPort = "8082"; // Default port
-            if(prop.getProperty("hostPort") != null) hostPort = prop.getProperty("hostPort");
-            if(line.hasOption("hp")) hostPort = line.getOptionValue("hp");
-            prop.setProperty("hostPort",hostPort);
-
-            if(hostAddress == null) line = null; // Host address is unknown. Can't continue.
-        }
-        if(line.hasOption("r")) {
-            prop.setProperty("restoreFile",line.getOptionValue("r"));
-        }
-        String staticFiles = type == RunnerType.WORKER ? "/workspace" : "/ui"; // Default values for worker:coordinator
-        if(prop.getProperty("staticfiles") != null) staticFiles = prop.getProperty("staticfiles");
-
-        if(prop.getProperty("workspace") == null) prop.setProperty("workspace", "workspace");
-        if(line.hasOption("sf")) staticFiles = line.getOptionValue("sf");
-        prop.setProperty("staticfiles",staticFiles);
-        if((line != null && line.hasOption("p")) || prop.getProperty("port") == null) {
-            LOGGER.info("Setting up port to listen on");
-            String defaultPort = prop.getProperty("port") != null ? prop.getProperty("port") : "8082";
-            prop.setProperty("port", (line.hasOption("p") ? line.getOptionValue("p") : defaultPort));
-        }
-        if((line != null && line.hasOption("a")) || prop.getProperty("address") == null) {
-            LOGGER.info("Setting host address");
-            String defaultIp = prop.getProperty("address") != null ? prop.getProperty("address") : getIPAddress();
-            prop.setProperty("address", (line.hasOption("a") ? line.getOptionValue("a") : defaultIp));
-        }
-        if(line == null || line.hasOption("h")) {
-            String header = "Run the Cthulhu task scheduler\n\n";
-            String footer = "\nPlease report issues at http://github.com/vitrivr/cthulhu/issues";
-            HelpFormatter formatter = new HelpFormatter();
-            formatter.printHelp("Cthulhu", header, options, footer, true);
-            line = null; // To instruct the main method to leave
-        }
-        return line;
+  public static CommandLine populateProperties(String[] args, Properties prop) throws Exception {
+    CommandLineParser parser = new DefaultParser();
+    Options options = new Options();
+    options.addOption("h", "help", false, "Display help menu");
+    options.addOption("C", "coordinator", false, "Run as coordinator");
+    options.addOption("W", "worker", false, "Run as worker");
+    options.addOption("ha", "hostAddress", true,
+                      "Address of coordinator host [for workers] - overrides properties file");
+    options.addOption("hp", "hostPort", true,
+                      "Port of coordinator host [for workers] - overrides properties file");
+    options.addOption("c", "capacity", true,
+                      "Capacity, or number of jobs that can run simultaneously [for workers]");
+    options.addOption("p", "port", true, "Port in which to listen to - overrides properties file");
+    options.addOption("a", "address", true,
+                      "Address of the local host (DNS? IP?) - overrides properties file");
+    options.addOption("sf", "staticFiles", true,
+                      "Directory where the static files will be read from (worker)");
+    options.addOption("r", "restore", true, "Restore instance from status file");
+    CommandLine line;
+    try {
+      line = parser.parse(options, args);
+    } catch (ParseException exp) {
+      line = null;
+      LOGGER.error("ERROR Parsing command line.");
     }
 
-    public static void restoreRun(Properties prop) throws Exception {
-        Gson restoreGson = new GsonBuilder()
-            .registerTypeAdapter(Job.class, new JobAdapter())
-            .create();
-        String jsonFile = prop.getProperty("restoreFile");
-        String jsonContents;
-        try {
-            InputStream is = new FileInputStream(jsonFile);
-            jsonContents = IOUtils.toString(is,"UTF-8");
-        } catch (Exception e) {
-            LOGGER.error("Unable to restore from file {}. Exception: {}",jsonFile,e.toString());
-            throw e;
-        }
-        CthulhuScheduler rs = restoreGson.fromJson(jsonContents, CoordinatorScheduler.class);
-        System.out.println(restoreGson.toJson(rs));
-        rs.restoreStatus();
-        ms = rs;
+    if (line != null && line.hasOption("W")) {
+      LOGGER.info("Starting up as worker");
+      type = RunnerType.WORKER; // Changing the runner type
+
+      String hostAddress = null;
+      if (prop.getProperty("hostAddress") != null) {
+        hostAddress = prop.getProperty("hostAddress");
+      }
+      if (line.hasOption("ha")) {
+        hostAddress = line.getOptionValue("ha");
+      }
+      prop.setProperty("hostAddress", hostAddress);
+
+      String hostPort = "8082"; // Default port
+      if (prop.getProperty("hostPort") != null) {
+        hostPort = prop.getProperty("hostPort");
+      }
+      if (line.hasOption("hp")) {
+        hostPort = line.getOptionValue("hp");
+      }
+      prop.setProperty("hostPort", hostPort);
+
+      if (hostAddress == null) {
+        line = null; // Host address is unknown. Can't continue.
+      }
+    }
+    if (line.hasOption("r")) {
+      prop.setProperty("restoreFile", line.getOptionValue("r"));
+    }
+    String staticFiles =
+        type == RunnerType.WORKER ? "/workspace" : "/ui"; // Default values for worker:coordinator
+    if (prop.getProperty("staticfiles") != null) {
+      staticFiles = prop.getProperty("staticfiles");
     }
 
-    public static void main(String[] args) throws Exception {
-        LOGGER.info("Loading properties");
-        Properties prop = new Properties();
-        try {
-            InputStream input = CthulhuRunner.class.getClassLoader().getResourceAsStream("cthulhu.properties");
-            prop.load(input);
-        } catch (IOException io) {
-            LOGGER.warn("Failed to load properties file. Using default settings.");
-        }
-        try {
-            LOGGER.info("Reading command line arguments");
-            CommandLine line = populateProperties(args,prop);
-            if(line == null) return;
-            
-            LOGGER.info("Starting up");
-            APICLIThread cli = new APICLIThread();
-            cli.start();
-            if(prop.getProperty("restoreFile") != null) {
-                restoreRun(prop);
-                prop = ms.getProperties();
-            } else {
-                SchedulerFactory sf = new SchedulerFactory();
-                ms = sf.createScheduler(type, prop); // Update later
-            }
-            ms.init();
-            api = new CthulhuREST();
-            api.init(ms,prop);
-        } catch (Exception e) {
-            LOGGER.info("Exception has been thrown during startup.");
-            if(ms != null) ms.stop();
-            if(api != null) api.stopServer();
-            System.exit(1);
-        }
+    if (prop.getProperty("workspace") == null) {
+      prop.setProperty("workspace", "workspace");
     }
+    if (line.hasOption("sf")) {
+      staticFiles = line.getOptionValue("sf");
+    }
+    prop.setProperty("staticfiles", staticFiles);
+    if ((line != null && line.hasOption("p")) || prop.getProperty("port") == null) {
+      LOGGER.info("Setting up port to listen on");
+      String defaultPort = prop.getProperty("port") != null ? prop.getProperty("port") : "8082";
+      prop.setProperty("port", (line.hasOption("p") ? line.getOptionValue("p") : defaultPort));
+    }
+    if ((line != null && line.hasOption("a")) || prop.getProperty("address") == null) {
+      LOGGER.info("Setting host address");
+      String defaultIp =
+          prop.getProperty("address") != null ? prop.getProperty("address") : getIPAddress();
+      prop.setProperty("address", (line.hasOption("a") ? line.getOptionValue("a") : defaultIp));
+    }
+    if (line == null || line.hasOption("h")) {
+      String header = "Run the Cthulhu task scheduler\n\n";
+      String footer = "\nPlease report issues at http://github.com/vitrivr/cthulhu/issues";
+      HelpFormatter formatter = new HelpFormatter();
+      formatter.printHelp("Cthulhu", header, options, footer, true);
+      line = null; // To instruct the main method to leave
+    }
+    return line;
+  }
 
-    private static final class APICLIThread extends Thread {
-        @Override
-        public void run() {
-            BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
-            String line = null;
-            try {
-                while ((line = reader.readLine()) != null) {
-                    line = line.trim();
-                    if (line.isEmpty()) {
-                        continue;
-                    }
-                    switch(line) {
-                    case "exit":
-                    case "quit":
-                        LOGGER.info("Exiting...");
-                        System.exit(0);
-                        break;
-                    default:
-                        System.out.println("Unrecognized command: "+line);
-                    }
-                }
-            } catch (IOException e) {
-                // Ignore the exception
-            }
-        }
+  public static void restoreRun(Properties prop) throws Exception {
+    Gson restoreGson = new GsonBuilder()
+        .registerTypeAdapter(Job.class, new JobAdapter())
+        .create();
+    String jsonFile = prop.getProperty("restoreFile");
+    String jsonContents;
+    try {
+      InputStream is = new FileInputStream(jsonFile);
+      jsonContents = IOUtils.toString(is, "UTF-8");
+    } catch (Exception e) {
+      LOGGER.error("Unable to restore from file {}. Exception: {}", jsonFile, e.toString());
+      throw e;
     }
+    CthulhuScheduler rs = restoreGson.fromJson(jsonContents, CoordinatorScheduler.class);
+    System.out.println(restoreGson.toJson(rs));
+    rs.restoreStatus();
+    ms = rs;
+  }
+
+  public static void main(String[] args) {
+    LOGGER.info("Loading properties");
+    Properties prop = new Properties();
+    try {
+      InputStream input = CthulhuRunner.class.getClassLoader()
+          .getResourceAsStream("cthulhu.properties");
+      prop.load(input);
+    } catch (IOException io) {
+      LOGGER.warn("Failed to load properties file. Using default settings.");
+    }
+    try {
+      LOGGER.info("Reading command line arguments");
+      CommandLine line = populateProperties(args, prop);
+      if (line == null) {
+        return;
+      }
+
+      LOGGER.info("Starting up");
+      APICLIThread cli = new APICLIThread();
+      cli.start();
+      if (prop.getProperty("restoreFile") != null) {
+        restoreRun(prop);
+        prop = ms.getProperties();
+      } else {
+        SchedulerFactory sf = new SchedulerFactory();
+        ms = sf.createScheduler(type, prop); // Update later
+      }
+      ms.init();
+      api = new CthulhuREST();
+      api.init(ms, prop);
+    } catch (Exception e) {
+      LOGGER.info("Exception has been thrown during startup.");
+      if (ms != null) {
+        ms.stop();
+      }
+      if (api != null) {
+        api.stopServer();
+      }
+      System.exit(1);
+    }
+  }
+
+  public enum RunnerType {
+    COORDINATOR,
+    WORKER
+  }
+
+  private static final class APICLIThread extends Thread {
+
+    @Override
+    public void run() {
+      BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
+      String line;
+      try {
+        while ((line = reader.readLine()) != null) {
+          line = line.trim();
+          if (line.isEmpty()) {
+            continue;
+          }
+          switch (line) {
+            case "exit":
+            case "quit":
+              LOGGER.info("Exiting...");
+              System.exit(0);
+              break;
+            default:
+              System.out.println("Unrecognized command: " + line);
+          }
+        }
+      } catch (IOException e) {
+        LOGGER.error("IO error while reading file", e);
+      }
+    }
+  }
 }

--- a/src/org/vitrivr/cthulhu/scheduler/CoordinatorScheduler.java
+++ b/src/org/vitrivr/cthulhu/scheduler/CoordinatorScheduler.java
@@ -1,210 +1,219 @@
 package org.vitrivr.cthulhu.scheduler;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import org.vitrivr.cthulhu.jobs.Job;
-import org.vitrivr.cthulhu.jobs.JobFactory;
-import org.vitrivr.cthulhu.jobs.JobQueue;
 import org.vitrivr.cthulhu.worker.Worker;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.ScheduledFuture;
-
-import java.util.List;
-import java.util.ArrayList;
-import java.util.Map;
-import java.util.HashMap;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.*;
-
-import java.util.Properties;
-
 public class CoordinatorScheduler extends CthulhuScheduler {
-    transient ScheduledExecutorService executor;
-    transient ScheduledFuture dispatchFuture;
-    int dispatchDelay = 10;
 
-    protected CoordinatorScheduler() {
-        this(null);
+  private transient ScheduledExecutorService executor;
+  private transient ScheduledFuture dispatchFuture;
+  private int dispatchDelay = 10;
+
+  protected CoordinatorScheduler() {
+    this(null);
+  }
+
+  public CoordinatorScheduler(Properties props) {
+    super(props);
+    wt = new ConcurrentHashMap<>();
+
+    if (props != null && props.getProperty("dispatchDelay") != null) {
+      dispatchDelay = Integer.parseInt(props.getProperty("dispatchDelay"));
     }
-    public CoordinatorScheduler(Properties props) {
-        super(props);
-        wt = new ConcurrentHashMap<String,Worker>();
-        
-        if(props != null && props.getProperty("dispatchDelay") != null) {
-            dispatchDelay = Integer.parseInt(props.getProperty("dispatchDelay"));
+  }
+
+  public void init() {
+    executor = Executors.newScheduledThreadPool(1);
+    dispatchFuture = executor
+        .scheduleAtFixedRate(this::runDispatch, dispatchDelay, dispatchDelay, TimeUnit.SECONDS);
+  }
+
+  public void stop() {
+    if (dispatchFuture != null) {
+      dispatchFuture.cancel(true);
+    }
+    if (executor != null) {
+      executor.shutdown();
+    }
+  }
+
+  public Worker getRunningWorker(Job job) {
+    return wt.entrySet()
+        .stream()
+        .filter(entry -> entry.getValue().hasJob(job.getName()))
+        .map(Map.Entry::getValue)
+        .findFirst().orElse(null);
+  }
+
+  @Override
+  protected void updateJobInt(Job job) throws Exception {
+    lg.info("Internal update of job {}", job.getName());
+    Worker w = getRunningWorker(job);
+    if (w == null) {
+      throw new Exception("Updated job not in any worker yet");
+    }
+    w.removeJob(job.getName());
+  }
+
+  @Override
+  protected void deleteJobInt(Job job, boolean force) throws Exception {
+    if (job.isRunning()) {
+      // Stop the job in the worker.
+      Worker w = getRunningWorker(job);
+      if (w == null) {
+        // This should never happen
+        lg.error("Could not find worker executing job {}. This is an error.", job.getName());
+        throw new Exception(
+            "Could not find worker executing job " + job.getName() + ". This is an error.");
+      }
+      try {
+        conn.deleteJob(job, w, true);
+      } catch (Exception e) {
+        lg.error("Failed to stop job in the worker: {}", e.toString());
+        throw e;
+        // This should not happen unless the worker became lost or inaccessible.
+      }
+    }
+  }
+
+  /**
+   *
+   */
+  public void restoreStatus() {
+    // 1. First we check with each worker if they are still up
+    List<String> goneWorkers = new ArrayList<>();
+    // We ask each worker to report on their status, and if they do not respond,
+    // we blacklist them (to re assign any jobs they might have been running)
+    HashMap<String, List<Job>> recoveredJobs = new HashMap<>();
+    List<Worker> recoveredWorkers = wt.entrySet().stream()
+        .filter(entry -> {
+          List<Job> wjobs;
+          try {
+            wjobs = jf.buildJobs(conn.getJobs(entry.getValue()));
+            lg.info("Worker {} has been found. It reported {} jobs.", entry.getKey(), wjobs.size());
+            recoveredJobs.put(entry.getKey(), wjobs);
+          } catch (Exception e) {
+            lg.info("Worker {} has been lost ({}).", entry.getKey(), e.toString());
+            goneWorkers.add(entry.getKey());
+            return false;
+          }
+          return true;
+        }).map(Entry::getValue).collect(Collectors.toList());
+    lg.info("Recovered {} workers. Lost {} workers.", recoveredWorkers.size(), goneWorkers.size());
+
+    // 2. Now we need to check each of the lost workers, and set their jobs as WAITING again
+    goneWorkers.forEach(wid -> {
+      Worker w = wt.get(wid);
+      // All the jobs in w are set to waiting
+      w.getJobs().forEach(j -> jt.get(j.getName()).setWaiting());
+      // Remove the worker from the worker table
+      wt.remove(wid);
+    });
+
+    // 3. Now we need to update the job status of jobs from recovered workers
+    recoveredWorkers.forEach(w -> {
+      String wId = w.getId();
+      // For each job that we recovered from the worker
+      recoveredJobs.get(wId).forEach(j -> {
+        // If it finished running (by failing, succeeding or being interrupted),
+        // we need only replace it on the job hash map
+        if (j.getStatus() == Job.Status.SUCCEEDED.getValue() ||
+            j.getStatus() == Job.Status.FAILED.getValue() ||
+            j.getStatus() == Job.Status.INTERRUPTED.getValue() ||
+            j.getStatus() == Job.Status.UNEXPECTED_ERROR.getValue()) {
+          jt.put(j.getName(), j);
+          // We mark it as removed from the worker (because it's done)
+          w.removeJob(j.getName());
+          return;
         }
-    }
-
-    public void init() {
-        executor = Executors.newScheduledThreadPool(1);
-        dispatchFuture = executor.scheduleAtFixedRate(new Runnable() {
-                public void run() {
-                    runDispatch();
-                }
-            }, dispatchDelay, dispatchDelay, TimeUnit.SECONDS);
-    }
-
-    public void stop() {
-        if(dispatchFuture != null) dispatchFuture.cancel(true);
-        if(executor != null) executor.shutdown();
-    }
-    public Worker getRunningWorker(Job job) {
-        Worker w = wt.entrySet()
-            .stream()
-            .filter(entry -> entry.getValue().hasJob(job.getName()))
-            .map(Map.Entry::getValue)
-            .findFirst().orElse(null);
-        return w;
-    }
-    @Override
-    protected void updateJobInt(Job job) throws Exception {
-        lg.info("Internal update of job {}",job.getName());
-        Worker w = getRunningWorker(job);
-        if(w == null) throw new Exception("Updated job not in any worker yet");
-        w.removeJob(job.getName());
-    }
-    @Override
-    protected void deleteJobInt(Job job, boolean force) throws Exception {
-        if(job.isRunning()) {
-            // Stop the job in the worker.
-            Worker w = getRunningWorker(job);
-            if(w == null) {
-                // This should never happen
-                lg.error("Could not find worker executing job {}. This is an error.",job.getName());
-                throw new Exception("Could not find worker executing job "+job.getName()+". This is an error.");
-            }
-            try {
-                conn.deleteJob(job,w,true);
-            } catch (Exception e) {
-                lg.error("Failed to stop job in the worker: {}",e.toString());
-                throw e;
-                // This should not happen unless the worker became lost or unaccessible.
-            }
-        }
-    }
-    /**
-     * 
-     */
-    public void restoreStatus() {
-        // 1. First we check with each worker if they are still up
-        List<String> goneWorkers = new ArrayList<String>();
-        // We ask each worker to report on their status, and if they do not respond,
-        // we blacklist them (to re assign any jobs they might have been runnning)
-        HashMap<String,List<Job>> recoveredJobs = new HashMap<String,List<Job>>();
-        List<Worker> recoveredWorkers = wt.entrySet().stream()
-            .filter(entry -> {
-                    List<Job> wjobs;
-                    try {
-                        wjobs = jf.buildJobs(conn.getJobs(entry.getValue()));
-                        lg.info("Worker {} has been found. It reported {} jobs.",entry.getKey(), wjobs.size());
-                        recoveredJobs.put(entry.getKey(),wjobs);
-                    } catch (Exception e) {
-                        lg.info("Worker {} has been lost ({}).",entry.getKey(), e.toString());
-                        goneWorkers.add(entry.getKey());
-                        return false;
-                    }
-                    return true;
-                }).map(entry-> entry.getValue()).collect(Collectors.toList());
-        lg.info("Recovered {} workers. Lost {} workers.", recoveredWorkers.size(), goneWorkers.size());
-
-        // 2. Now we need to check each of the lost workers, and set their jobs as WAITING again
-        goneWorkers.stream().forEach(wid->{
-                Worker w = wt.get(wid);
-                // All the jobs in w are set to waiting
-                w.getJobs().stream().forEach(j->{ jt.get(j.getName()).setWaiting(); });
-                // Remove the worker from the worker table
-                wt.remove(wid);
-            });
-
-        // 3. Now we need to update the job status of jobs from recovered workers
-        recoveredWorkers.stream().forEach(w -> {
-                String wId = w.getId();
-                // For each job that we recovered from the worker
-                recoveredJobs.get(wId).stream().forEach(j->{
-                        // If it finished running (by failing, succeeding or being interrupted),
-                        // we need only replace it on the job hash map
-                        if(j.getStatus() == Job.Status.SUCCEEDED.getValue() || 
-                           j.getStatus() == Job.Status.FAILED.getValue() || 
-                           j.getStatus() == Job.Status.INTERRUPTED.getValue() ||
-                           j.getStatus() == Job.Status.UNEXPECTED_ERROR.getValue()) {
-                            jt.put(j.getName(),j);
-                            // We mark it as removed from the worker (because it's done)
-                            w.removeJob(j.getName());
-                            return ;
-                        }
                         /* If a job is running in the worker, then it must be running in
                            the restored coordinator. If that's the case, then all is consistent */
-                        if(j.isRunning() && w.getJob(j.getName()).isRunning()) { return ; }
-
-                        /* Otherwise, the state of the job is inconsistent, and it should be reviewed */
-                        lg.error("Inconsistent state for job {}. Coord status: {}. Worker status: {}",
-                                j.getName(), w.getJob(j.getName()).getStatus(), j.getStatus());
-                    });
-                
-            });
-        // 4. Finally, we add all waiting jobs to the job queue.
-        jt.entrySet().stream()
-            .map(e->e.getValue())
-            .filter(j->j.getStatus() == Job.Status.WAITING.getValue())
-            .forEach(j -> {
-                    jq.push(j);
-                    lg.trace("Inserting job {} to job queue",j.getName());
-                        });
-        lg.info("Job queue size after restore is {}",jq.size());
-        lg.info("Done restoring the coordinator status");
-    }
-    public void runDispatch() {
-        // 1. The first stage of the dispatching cycle is to update jobs that have
-        //    finished running
-
-        // 2. The second stage of the dispatching cycle is to dispatch jobs.
-        List<Worker> availableWks = getWorkers().stream()
-            .filter(w -> w.getCapacity() > w.getJQSize()).collect(Collectors.toList());
-        int freeCapacity = availableWks.stream().mapToInt(w-> w.getCapacity() - w.getJQSize()).sum();
-        int wCount = 0;
-        int jobsDispatched = 0;
-        Job nextJob = null;
-        if(freeCapacity > 0) {
-            lg.info("Starting the dispatch of {} jobs to {} spots in {} workers.",
-                    Integer.toString(jq.size()),Integer.toString(freeCapacity),
-                    Integer.toString(availableWks.size()));
-        } else {
-            lg.trace("Unable to dispatch. Jobs waiting: {}. Available capacity: {}",
-                     Integer.toString(jq.size()),Integer.toString(freeCapacity));
+        if (j.isRunning() && w.getJob(j.getName()).isRunning()) {
+          return;
         }
-        while(freeCapacity > 0 && jq.size() > 0) {
-            Worker currWorker = availableWks.get(wCount % availableWks.size());
-            wCount += 1; // Increase the worker round robin count
 
-            // If the worker is at capacity, we skip this worker
-            if(currWorker.getCapacity() <= currWorker.getJQSize()) continue;
+        /* Otherwise, the state of the job is inconsistent, and it should be reviewed */
+        lg.error("Inconsistent state for job {}. Coord status: {}. Worker status: {}",
+                 j.getName(), w.getJob(j.getName()).getStatus(), j.getStatus());
+      });
 
-            // We submit the job
-            if(nextJob == null) nextJob = jq.pop();
-            lg.trace("Posting job {} to worker {}.",
-                     nextJob.getName(),currWorker.getId());
-            try {
-                currWorker.addJob(nextJob);
-                nextJob.setRunning();
-                conn.postJob(nextJob,currWorker);
-                nextJob = null;
-            } catch (Exception e) {
-                lg.warn("Problems posting job {} to worker {}: {}",
-                        nextJob.getName(),currWorker.getId(),e.toString());
-                currWorker.removeJob(nextJob.getName());
-                nextJob.setWaiting();
-                freeCapacity -= 1;
-                continue;
-            }
-            freeCapacity -= 1;
-            jobsDispatched += 1;
-        }
-        lg.info("Dispatched {} jobs",jobsDispatched);
-        lg.info("Writing status to disk.");
-        sk.saveStatus(this);
+    });
+    // 4. Finally, we add all waiting jobs to the job queue.
+    jt.entrySet().stream()
+        .map(Entry::getValue)
+        .filter(j -> j.getStatus() == Job.Status.WAITING.getValue())
+        .forEach(j -> {
+          jq.push(j);
+          lg.trace("Inserting job {} to job queue", j.getName());
+        });
+    lg.info("Job queue size after restore is {}", jq.size());
+    lg.info("Done restoring the coordinator status");
+  }
+
+  public void runDispatch() {
+    // 1. The first stage of the dispatching cycle is to update jobs that have
+    //    finished running
+
+    // 2. The second stage of the dispatching cycle is to dispatch jobs.
+    List<Worker> availableWks = getWorkers().stream()
+        .filter(w -> w.getCapacity() > w.getJQSize()).collect(Collectors.toList());
+    int freeCapacity = availableWks.stream().mapToInt(w -> w.getCapacity() - w.getJQSize()).sum();
+    int wCount = 0;
+    int jobsDispatched = 0;
+    Job nextJob = null;
+    if (freeCapacity > 0) {
+      lg.info("Starting the dispatch of {} jobs to {} spots in {} workers.",
+              Integer.toString(jq.size()), Integer.toString(freeCapacity),
+              Integer.toString(availableWks.size()));
+    } else {
+      lg.trace("Unable to dispatch. Jobs waiting: {}. Available capacity: {}",
+               Integer.toString(jq.size()), Integer.toString(freeCapacity));
     }
+    while (freeCapacity > 0 && jq.size() > 0) {
+      Worker currWorker = availableWks.get(wCount % availableWks.size());
+      wCount += 1; // Increase the worker round robin count
+
+      // If the worker is at capacity, we skip this worker
+      if (currWorker.getCapacity() <= currWorker.getJQSize()) {
+        continue;
+      }
+
+      // We submit the job
+      if (nextJob == null) {
+        nextJob = jq.pop();
+      }
+      lg.trace("Posting job {} to worker {}.",
+               nextJob.getName(), currWorker.getId());
+      try {
+        currWorker.addJob(nextJob);
+        nextJob.setRunning();
+        conn.postJob(nextJob, currWorker);
+        nextJob = null;
+      } catch (Exception e) {
+        lg.warn("Problems posting job {} to worker {}: {}",
+                nextJob.getName(), currWorker.getId(), e.toString());
+        currWorker.removeJob(nextJob.getName());
+        nextJob.setWaiting();
+        freeCapacity -= 1;
+        continue;
+      }
+      freeCapacity -= 1;
+      jobsDispatched += 1;
+    }
+    lg.info("Dispatched {} jobs", jobsDispatched);
+    lg.info("Writing status to disk.");
+    sk.saveStatus(this);
+  }
 }

--- a/src/org/vitrivr/cthulhu/scheduler/CthulhuScheduler.java
+++ b/src/org/vitrivr/cthulhu/scheduler/CthulhuScheduler.java
@@ -1,234 +1,255 @@
 package org.vitrivr.cthulhu.scheduler;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.vitrivr.cthulhu.jobs.Job;
 import org.vitrivr.cthulhu.jobs.JobFactory;
 import org.vitrivr.cthulhu.jobs.JobQueue;
 import org.vitrivr.cthulhu.jobs.JobTools;
+import org.vitrivr.cthulhu.keeper.JsonKeeper;
+import org.vitrivr.cthulhu.keeper.StatusKeeper;
+import org.vitrivr.cthulhu.rest.CthulhuRESTConnector;
 import org.vitrivr.cthulhu.worker.Worker;
 
-import org.vitrivr.cthulhu.keeper.StatusKeeper;
-import org.vitrivr.cthulhu.keeper.JsonKeeper;
-
-import org.vitrivr.cthulhu.rest.CthulhuRESTConnector;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.*;
-
-import java.util.Properties;
-
-import com.google.gson.annotations.Expose;
-
 public abstract class CthulhuScheduler {
-    transient protected StatusKeeper sk;
-    transient protected CthulhuRESTConnector conn;
-    transient protected JobQueue jq;
-    transient protected Logger lg;
-    transient protected JobTools jobTools;
-    transient protected JobFactory jf;
-    /**
-     * The worker table. It's a hash table of workers, mapped by their address:port string.
-     */
-    protected Map<String,Worker> wt; // Worker table
-    /**
-     * The job table. It's the table with all the jobs (waiting, running, failed or successful jobs) in the system
-     */
-    protected Map<String,Job> jt; // Job table
-    /**
-     * Runtime properties of this agent
-     */
-    protected Properties props;
-    public CthulhuScheduler() {
-        this(null);
-    }
-    public CthulhuScheduler(Properties props) {
-        sk = new JsonKeeper(props);
-        jq = new JobQueue();
-        jf = new JobFactory();
-        jt = new ConcurrentHashMap<String,Job>();
-        conn = new CthulhuRESTConnector();
-        this.props = props;
-        lg = LogManager.getLogger("r.m.ms"); // master.masterscheduler
-        jobTools = new JobTools(props, conn);
-        jf.setTools(jobTools);
-    }
-    /**
-     * Updates a job with a new definition
-     * <p>
-     * Takes in a JSON job definition, creates a new job from it, and substitutes
-     * an existing job. If the job does not exist already, the new job definition
-     * is not inserted, and the function returns null.
-     *
-     * @param jobDefinition the JSON string defining the new job
-     * @return the old job object
-     */
-    public Job updateJob(String jobDefinition) {
-        Job job = jf.buildJob(jobDefinition);
-        lg.info("Updating job {}",job.getName());
-        Job oldJob = jt.get(job.getName());
-        if(oldJob == null) {
-            lg.warn("Job {} not existing - unable to update",job.getName());
-            return null;
-        }
-        try {
-            updateJobInt(job);
-        } catch (Exception e) {
-            lg.error("Internal job update failed: {}",e.toString());
-        }
-        jt.remove(job.getName());
-        jt.put(job.getName(),job);
-        return oldJob;
-    }
 
-    /**
-     * Creates a new job and saves it in the job table
-     * <p>
-     * Takes in a JSON job definition, creates a new job from it, and inserts it into
-     * the job table (and job queue if the job is ready to run, and this is a coordinator).
-     *
-     * @param jobDefinition the JSON string defining the new job
-     * @return the job object of the job that we created. If no job was created, it returns null.
-     */
-    public Job registerJob(String jobDefinition) {
-        Job job = null;
-        try {
-            job = jf.buildJob(jobDefinition);
-        } catch (Exception e) {
-            return job;
-        }
-        jq.push(job);
-        jt.put(job.getName(),job);
-        lg.info("Created job {}",job.getName());
-        schedulerTick();
-        return job;
-    }
-    /**
-     * Registers a new worker with the coordinator.
-     * <p>
-     * 
-     * @param address The ip address or name of the remote host of the worker
-     * @param port The port number where the worker is listening for communication with the coordinator
-     * @return integer 0 if all went well
-     */
-    public int registerWorker(String address, int port) {
-        Worker w = new Worker(address,port);
-        wt.put(w.getId(),w);
-        lg.info("Registered worker in {}",w.getAddress());
-        return 0;
-    }
-    /**
-     * Obtains a list of all the jobs known to this agent
-     * <p>
-     *
-     * @return a list of all the jobs in the job table
-     */
-    public List<Job> getJobs() {
-        return jt.entrySet()
-            .stream()
-            .map(entry -> entry.getValue())
-            .collect(Collectors.toList());
-    }
-    /**
-     * Obtains a job according to its name
-     * <p>
-     * If the job does not exist, null will be returned.
-     *
-     * @param jobId the name of the job
-     * @return Job object with name equal to the jobId parameter or null
-     */
-    public Job getJobs(String jobId) {
-        return jt.get(jobId);
-    }
-    /**
-     * Obtains a list of all the workers known to this agent
-     * <p>
-     * If this is a WorkerScheduler, it just returns null.
-     * 
-     * @return a list of all the workers in the worker table
-     */
-    public List<Worker> getWorkers() {
-        if(wt == null) return null;
-        return wt.entrySet()
-            .stream()
-            .map(entry -> entry.getValue())
-            .collect(Collectors.toList());
-    }
-    /**
-     * Obtains a host according to its address and port
-     * <p>
-     * If there are no registered hosts under that address:port, null will be returned
-     *
-     * @param workerId of the host in hostname:port format
-     * @return Worker object with said hostname:port id
-     */
-    public Worker getWorkers(String workerId) {
-        return wt.get(workerId);
-    }
-    /**
-     * Deletes a job with a specific job id. Force parameter set to false.
-     * <p>
-     * If the job is running, or does not exist, this call will throw an exception.
-     *
-     * @param jobId The name of the job to delete
-     * @return The job object that was removed from the job table
-     */
-    public Job deleteJob(String jobId) throws Exception {
-        return deleteJob(jobId, false);
-    }
-    /**
-     * Deletes a job with a specific job id.
-     * <p>
-     * If the job is running, and force is set to false this call will throw an exception.
-     * If the job is running and force is set to true, the job will first be stopped, and then it will be deleted
-     *
-     * @param jobId The name of the job to delete
-     * @param force indicatess whether to force deletion by stopping the job
-     * @return The job object that was removed from the job table
-     */
-    public Job deleteJob(String jobId, boolean force) throws Exception {
-        Job j = jt.get(jobId);
-        lg.info("Deleting job {} with force = {}",jobId, force == true ? "TRUE" : "FALSE");
-        if(j == null || (j.isRunning() && force == false)) {
-            lg.warn("Can not delete job {}. Job does not exist or is running and force is set to FALSE", jobId);
-            throw new Exception("Can not delete job that is running. Wait until it finishes, or use force=True.");
-        }
-        deleteJobInt(j,force); 
-        // If an exception is thrown, the job is not deleted
-        return jt.remove(jobId);
-    }
+  transient StatusKeeper sk;
+  transient CthulhuRESTConnector conn;
+  transient JobQueue jq;
+  transient Logger lg;
+  transient JobTools jobTools;
+  transient JobFactory jf;
+  /**
+   * The worker table. It's a hash table of workers, mapped by their address:port string.
+   */
+  Map<String, Worker> wt; // Worker table
+  /**
+   * The job table. It's the table with all the jobs (waiting, running, failed or successful jobs)
+   * in the system
+   */
+  Map<String, Job> jt; // Job table
+  /**
+   * Runtime properties of this agent
+   */
+  protected Properties props;
 
-    /**
-     * Internal routine for job deletion. To be reimplemented by subclasses.
-     */
-    protected void deleteJobInt(Job job, boolean force) throws Exception {
-    }
-    /**
-     * Deletes a job with a specific address:port identifier
-     * <p>
-     * If the worker is not registered, null is returned. Otherwise, the worker object is.
-     *
-     * @param workerId of the host in hostname:port format
-     * @return Worker object that was deleted with said hostname:port id
-     */
-    public Worker deleteWorker(String workerId) {
-        return wt.remove(workerId);
-    }
+  public CthulhuScheduler() {
+    this(null);
+  }
 
-    public void restoreStatus() {
+  public CthulhuScheduler(Properties props) {
+    sk = new JsonKeeper(props);
+    jq = new JobQueue();
+    jf = new JobFactory();
+    jt = new ConcurrentHashMap<>();
+    conn = new CthulhuRESTConnector();
+    this.props = props;
+    lg = LogManager.getLogger("r.m.ms"); // master.masterscheduler
+    jobTools = new JobTools(props, conn);
+    jf.setTools(jobTools);
+  }
+
+  /**
+   * Updates a job with a new definition
+   * <p>
+   * Takes in a JSON job definition, creates a new job from it, and substitutes an existing job. If
+   * the job does not exist already, the new job definition is not inserted, and the function
+   * returns null.
+   *
+   * @param jobDefinition the JSON string defining the new job
+   * @return the old job object
+   */
+  public Job updateJob(String jobDefinition) {
+    Job job = jf.buildJob(jobDefinition);
+    lg.info("Updating job {}", job.getName());
+    Job oldJob = jt.get(job.getName());
+    if (oldJob == null) {
+      lg.warn("Job {} not existing - unable to update", job.getName());
+      return null;
     }
-    protected void setConn(CthulhuRESTConnector conn) {
-        this.conn = conn;
+    try {
+      updateJobInt(job);
+    } catch (Exception e) {
+      lg.error("Internal job update failed: {}", e.toString());
     }
-    public Properties getProperties() { return props; }
-    protected void updateJobInt(Job job) throws Exception {
+    jt.remove(job.getName());
+    jt.put(job.getName(), job);
+    return oldJob;
+  }
+
+  /**
+   * Creates a new job and saves it in the job table
+   * <p>
+   * Takes in a JSON job definition, creates a new job from it, and inserts it into the job table
+   * (and job queue if the job is ready to run, and this is a coordinator).
+   *
+   * @param jobDefinition the JSON string defining the new job
+   * @return the job object of the job that we created. If no job was created, it returns null.
+   */
+  public Job registerJob(String jobDefinition) {
+    Job job = null;
+    try {
+      job = jf.buildJob(jobDefinition);
+    } catch (Exception e) {
+      return job;
     }
-    protected void schedulerTick() {
+    jq.push(job);
+    jt.put(job.getName(), job);
+    lg.info("Created job {}", job.getName());
+    schedulerTick();
+    return job;
+  }
+
+  /**
+   * Registers a new worker with the coordinator.
+   * <p>
+   *
+   * @param address The ip address or name of the remote host of the worker
+   * @param port The port number where the worker is listening for communication with the
+   *     coordinator
+   * @return integer 0 if all went well
+   */
+  public int registerWorker(String address, int port) {
+    Worker w = new Worker(address, port);
+    wt.put(w.getId(), w);
+    lg.info("Registered worker in {}", w.getAddress());
+    return 0;
+  }
+
+  /**
+   * Obtains a list of all the jobs known to this agent
+   * <p>
+   *
+   * @return a list of all the jobs in the job table
+   */
+  public List<Job> getJobs() {
+    return jt.entrySet()
+        .stream()
+        .map(Entry::getValue)
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Obtains a job according to its name
+   * <p>
+   * If the job does not exist, null will be returned.
+   *
+   * @param jobId the name of the job
+   * @return Job object with name equal to the jobId parameter or null
+   */
+  public Job getJobs(String jobId) {
+    return jt.get(jobId);
+  }
+
+  /**
+   * Obtains a list of all the workers known to this agent
+   * <p>
+   * If this is a WorkerScheduler, it just returns null.
+   *
+   * @return a list of all the workers in the worker table
+   */
+  public List<Worker> getWorkers() {
+    if (wt == null) {
+      return null;
     }
-    public void stop() {
+    return new ArrayList<>(wt.values());
+  }
+
+  /**
+   * Obtains a host according to its address and port
+   * <p>
+   * If there are no registered hosts under that address:port, null will be returned
+   *
+   * @param workerId of the host in hostname:port format
+   * @return Worker object with said hostname:port id
+   */
+  public Worker getWorkers(String workerId) {
+    return wt.get(workerId);
+  }
+
+  /**
+   * Deletes a job with a specific job id. Force parameter set to false.
+   * <p>
+   * If the job is running, or does not exist, this call will throw an exception.
+   *
+   * @param jobId The name of the job to delete
+   * @return The job object that was removed from the job table
+   */
+  public Job deleteJob(String jobId) throws Exception {
+    return deleteJob(jobId, false);
+  }
+
+  /**
+   * Deletes a job with a specific job id.
+   * <p>
+   * If the job is running, and force is set to false this call will throw an exception. If the job
+   * is running and force is set to true, the job will first be stopped, and then it will be
+   * deleted
+   *
+   * @param jobId The name of the job to delete
+   * @param force indicatess whether to force deletion by stopping the job
+   * @return The job object that was removed from the job table
+   */
+  public Job deleteJob(String jobId, boolean force) throws Exception {
+    Job j = jt.get(jobId);
+    lg.info("Deleting job {} with force = {}", jobId, force ? "TRUE" : "FALSE");
+    if (j == null || (j.isRunning() && !force)) {
+      lg.warn(
+          "Can not delete job {}. Job does not exist or is running and force is set to FALSE",
+          jobId);
+      throw new Exception(
+          "Can not delete job that is running. Wait until it finishes, or use force=True.");
     }
-    public void init(){}
+    deleteJobInt(j, force);
+    // If an exception is thrown, the job is not deleted
+    return jt.remove(jobId);
+  }
+
+  /**
+   * Internal routine for job deletion. To be reimplemented by subclasses.
+   */
+  protected void deleteJobInt(Job job, boolean force) throws Exception {
+  }
+
+  /**
+   * Deletes a job with a specific address:port identifier
+   * <p>
+   * If the worker is not registered, null is returned. Otherwise, the worker object is.
+   *
+   * @param workerId of the host in hostname:port format
+   * @return Worker object that was deleted with said hostname:port id
+   */
+  public Worker deleteWorker(String workerId) {
+    return wt.remove(workerId);
+  }
+
+  public void restoreStatus() {
+  }
+
+  protected void setConn(CthulhuRESTConnector conn) {
+    this.conn = conn;
+  }
+
+  public Properties getProperties() {
+    return props;
+  }
+
+  protected void updateJobInt(Job job) throws Exception {
+  }
+
+  protected void schedulerTick() {
+  }
+
+  public void stop() {
+  }
+
+  public void init() {
+  }
 }

--- a/src/org/vitrivr/cthulhu/scheduler/SchedulerFactory.java
+++ b/src/org/vitrivr/cthulhu/scheduler/SchedulerFactory.java
@@ -1,25 +1,27 @@
 package org.vitrivr.cthulhu.scheduler;
 
-import org.vitrivr.cthulhu.runners.CthulhuRunner.RunnerType;
-
 import java.util.Properties;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.vitrivr.cthulhu.runners.CthulhuRunner.RunnerType;
 
 public class SchedulerFactory {
-    private Logger LOGGER;
-    public SchedulerFactory() {
-        LOGGER = LogManager.getLogger("r.sf");
+
+  private Logger LOGGER;
+
+  public SchedulerFactory() {
+    LOGGER = LogManager.getLogger("r.sf");
+  }
+
+  public CthulhuScheduler createScheduler(RunnerType type, Properties props) {
+    if (type == RunnerType.WORKER) {
+      LOGGER.info("Creating a WorkerScheduler");
+      return new WorkerScheduler(props);
     }
-    public CthulhuScheduler createScheduler(RunnerType type, Properties props) {
-        if(type == RunnerType.WORKER) {
-            LOGGER.info("Creating a WorkerScheduler");
-            return new WorkerScheduler(props);
-        }
-        if(type == RunnerType.COORDINATOR) {
-            LOGGER.info("Creating a CoordinatorScheduler");
-            return new CoordinatorScheduler(props);
-        }
-        return null;
+    if (type == RunnerType.COORDINATOR) {
+      LOGGER.info("Creating a CoordinatorScheduler");
+      return new CoordinatorScheduler(props);
     }
+    return null;
+  }
 }

--- a/src/org/vitrivr/cthulhu/scheduler/WorkerScheduler.java
+++ b/src/org/vitrivr/cthulhu/scheduler/WorkerScheduler.java
@@ -1,162 +1,173 @@
 package org.vitrivr.cthulhu.scheduler;
 
-import org.vitrivr.cthulhu.jobs.Job;
-import org.vitrivr.cthulhu.jobs.JobFactory;
-import org.vitrivr.cthulhu.jobs.JobQueue;
-import org.vitrivr.cthulhu.jobs.JobTools;
-
-import org.vitrivr.cthulhu.worker.Worker;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.ScheduledFuture;
-
-import java.lang.InterruptedException;
-
-import java.util.List;
 import java.util.LinkedList;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.*;
-
 import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import org.vitrivr.cthulhu.jobs.Job;
+import org.vitrivr.cthulhu.jobs.JobTools;
+import org.vitrivr.cthulhu.worker.Worker;
 
 public class WorkerScheduler extends CthulhuScheduler {
-    Worker coordinator;
-    int capacity = 1; // Default capacity - to be changed later
-    Map<String,Thread> jobExecutors; // List of job executors
-    LinkedList<Job> doneJobQueue;
-    ScheduledFuture coordinatorPoller = null;
 
-    public WorkerScheduler(Properties props) {
-        this(props,false);
-    }
-    public WorkerScheduler(Properties props, boolean standAlone) {
-        super(props);
-        jobExecutors = new ConcurrentHashMap<String,Thread>();
-        doneJobQueue = new LinkedList<Job>();
-        if(!standAlone) {
-            coordinator = new Worker(props != null ? props.getProperty("hostAddress") : "127.0.0.1",
-                                     props != null ? Integer.parseInt(props.getProperty("hostPort")) : 8082);
-            int port = Integer.parseInt(props != null ? props.getProperty("port") : "8081");
-            informCoordinator(props != null ? props.getProperty("address") : "127.0.0.1", port);
-            jobTools = new JobTools(props, conn, coordinator); // Resetting the job tools
-            jf.setTools(jobTools);
-        }
-    }
+  private Worker coordinator;
+  private Map<String, Thread> jobExecutors; // List of job executors
+  private LinkedList<Job> doneJobQueue;
+  private ScheduledFuture coordinatorPoller = null;
 
-    /**
-     * Stops the periodic polling of the coordinator 
-     * <p>
-     */
-    void stopWaitingForCoord() {
-        if(coordinatorPoller != null) coordinatorPoller.cancel(false);
-        coordinatorPoller = null;
-    }
+  public WorkerScheduler(Properties props) {
+    this(props, false);
+  }
 
-    /**
-     * Polls for the coordinator until it comes back, or the worker is terminated.
-     * <p>
-     */
-    void waitForCoord() {
-        lg.info("Starting the polling for the coordinator");
-        int pollDelay = 10;
-        ScheduledExecutorService executor = Executors.newScheduledThreadPool(1);
-        coordinatorPoller = executor.scheduleAtFixedRate(()->{
-                try { 
-                    returnFinalizedJobs();
-                } catch (Exception e) {
-                    lg.warn("Coordinator still not available");
-                    return ;
-                }
-                lg.info("Coordinator has been recovered!");
-                schedulerTick();
-                stopWaitingForCoord();
-            }, pollDelay, pollDelay, TimeUnit.SECONDS);
+  public WorkerScheduler(Properties props, boolean standAlone) {
+    super(props);
+    jobExecutors = new ConcurrentHashMap<>();
+    doneJobQueue = new LinkedList<>();
+    if (!standAlone) {
+      coordinator = new Worker(
+          props != null ? props.getProperty("hostAddress") : "127.0.0.1",
+          props != null ? Integer.parseInt(props.getProperty("hostPort")) : 8082);
+      int port = Integer.parseInt(props != null ? props.getProperty("port") : "8081");
+      informCoordinator(props != null ? props.getProperty("address") : "127.0.0.1", port);
+      jobTools = new JobTools(props, conn, coordinator); // Resetting the job tools
+      jf.setTools(jobTools);
     }
-    /**
-     * This function assumes that all the checks have been done, and it is
-     * safe to run a job in a new thread. (i.e. assumes that the capacity allows
-     * to run one more job).
-     */
-    void executeNextJob() {
-        if(jq.size() == 0) return;
-        Job nextJob = jq.pop();
-        lg.info("Starting to execute job {}",nextJob.getName());
+  }
+
+  /**
+   * Stops the periodic polling of the coordinator
+   * <p>
+   */
+  private void stopWaitingForCoord() {
+    if (coordinatorPoller != null) {
+      coordinatorPoller.cancel(false);
+    }
+    coordinatorPoller = null;
+  }
+
+  /**
+   * Polls for the coordinator until it comes back, or the worker is terminated.
+   * <p>
+   */
+  private void waitForCoord() {
+    lg.info("Starting the polling for the coordinator");
+    int pollDelay = 10;
+    ScheduledExecutorService executor = Executors.newScheduledThreadPool(1);
+    coordinatorPoller = executor.scheduleAtFixedRate(() -> {
+      try {
+        returnFinalizedJobs();
+      } catch (Exception e) {
+        lg.warn("Coordinator still not available");
+        return;
+      }
+      lg.info("Coordinator has been recovered!");
+      schedulerTick();
+      stopWaitingForCoord();
+    }, pollDelay, pollDelay, TimeUnit.SECONDS);
+  }
+
+  /**
+   * This function assumes that all the checks have been done, and it is safe to run a job in a new
+   * thread. (i.e. assumes that the capacity allows to run one more job).
+   */
+  private void executeNextJob() {
+    if (jq.size() == 0) {
+      return;
+    }
+    Job nextJob = jq.pop();
+    lg.info("Starting to execute job {}", nextJob.getName());
 
         /* Job is executed simply inside a thread. Unless we need 
            more sophisticaded execution logic, we'll use a  simple 
            lambda as the Runner interface passed to Thread t */
-        Thread t = new Thread(()-> {
-                int result = 0;
-                result = nextJob.execute();
-                String strResult = result == 0 ? "SUCCESS" : "FAILURE";
-                strResult = nextJob.wasInterrupted() ? "INTERRUPTED" : strResult;
-                lg.info("Job execution of job {} finalized with {}",
-                        nextJob.getName(),strResult);
-                finalizeJobExecution(nextJob);
-            });
-        jobExecutors.put(nextJob.getName(), t);
-        t.start();
+    Thread t = new Thread(() -> {
+      int result = 0;
+      result = nextJob.execute();
+      String strResult = result == 0 ? "SUCCESS" : "FAILURE";
+      strResult = nextJob.wasInterrupted() ? "INTERRUPTED" : strResult;
+      lg.info("Job execution of job {} finalized with {}",
+              nextJob.getName(), strResult);
+      finalizeJobExecution(nextJob);
+    });
+    jobExecutors.put(nextJob.getName(), t);
+    t.start();
+  }
+
+  private void returnFinalizedJobs() throws Exception {
+    while (doneJobQueue.size() > 0) {
+      Job j = doneJobQueue.poll();
+      if (j == null) {
+        continue; // This should never happen
+      }
+      if (coordinator != null) {
+        conn.putJob(j, coordinator);
+      }
+      // After reporting the result of the job, we remove it from the job table
+      // TODO: Pick up of job results
+      jt.remove(j.getName());
+      if (jobExecutors.containsKey(j.getName())) {
+        jobExecutors.remove(j.getName());
+      }
     }
-    void returnFinalizedJobs() throws Exception {
-        while(doneJobQueue.size() > 0) {
-            Job j = doneJobQueue.poll();
-            if(j == null) continue; // This should never happen
-            if(coordinator != null) conn.putJob(j, coordinator);
-            // After reporting the result of the job, we remove it from the job table
-            // TODO: Pick up of job results
-            jt.remove(j.getName());
-            if(jobExecutors.containsKey(j.getName())) jobExecutors.remove(j.getName());
-        }
+  }
+
+  private void finalizeJobExecution(Job j) {
+    // TODO THIS MUST EXECUTE EVEN IF THE JOB WAS DELETED AND STOPPED.
+    try {
+      lg.info("Reporting result of job {} to coordinator.", j.getName());
+      doneJobQueue.add(j);
+      returnFinalizedJobs();
+    } catch (Exception e) {
+      lg.error(
+          "Unable to report result of job {} to coordinator {}: {}",
+          j.getName(),
+          coordinator != null ? coordinator.getId() : "STANDALONE",
+          e.toString());
+      // In this case, we return without the next schedulerTick,
+      // if we recover the coordinator, then waitForCoord will execute it.
+      waitForCoord();
+      return;
     }
-    void finalizeJobExecution(Job j) {
-        // TODO THIS MUST EXECUTE EVEN IF THE JOB WAS DELETED AND STOPPED.
-        try {
-            lg.info("Reporting result of job {} to coordinator.",j.getName());
-            doneJobQueue.add(j);
-            returnFinalizedJobs();
-        } catch (Exception e) {
-            lg.error("Unable to report result of job {} to coordinator {}: {}",
-                     j.getName(),
-                     coordinator != null ? coordinator.getId() : "STANDALONE",
-                     e.toString());
-            // In this case, we return without the next schedulerTick,
-            // if we recover the coordinator, then waitForCoord will execute it.
-            waitForCoord();
-            return ;
-        }
-        schedulerTick();
+    schedulerTick();
+  }
+
+  @Override
+  protected void deleteJobInt(Job job, boolean force) throws Exception {
+    if (!force) {
+      return;
     }
-    @Override
-    protected void deleteJobInt(Job job, boolean force) throws Exception {
-        if(force == false) return ;
-        Thread exec = jobExecutors.get(job.getName());
-        if(exec == null) {
-            lg.warn("Job {} has finished running before it was deleted.",job.getName());
-        }
-        lg.info("Sending interruption to job executor of {}",job.getName());
-        exec.interrupt();
-        // TODO - can this fail?
-        // If all went fine, then we remove it!
-        jt.remove(job.getName());
-        jobExecutors.remove(job.getName());
+    Thread exec = jobExecutors.get(job.getName());
+    if (exec == null) {
+      lg.warn("Job {} has finished running before it was deleted.", job.getName());
     }
-    @Override
-    protected void schedulerTick() {
-        if(jobExecutors.size() < capacity) executeNextJob();
+    lg.info("Sending interruption to job executor of {}", job.getName());
+    exec.interrupt();
+    // TODO - can this fail?
+    // If all went fine, then we remove it!
+    jt.remove(job.getName());
+    jobExecutors.remove(job.getName());
+  }
+
+  @Override
+  protected void schedulerTick() {
+    // Default capacity - to be changed later
+    int capacity = 1;
+    if (jobExecutors.size() < capacity) {
+      executeNextJob();
     }
-    void informCoordinator(String workerAddress, int workerPort) {
-        lg.info("Registering worker with coordinator {}",coordinator.getId());
-        try {
-            conn.postWorker(coordinator,workerAddress,workerPort);
-        } catch (Exception e) {
-            lg.error("Failed to register with coordinator: {}",e.toString());
-            System.exit(1); // Exiting. Need a coordinator or nothing can be done.
-        }
+  }
+
+  private void informCoordinator(String workerAddress, int workerPort) {
+    lg.info("Registering worker with coordinator {}", coordinator.getId());
+    try {
+      conn.postWorker(coordinator, workerAddress, workerPort);
+    } catch (Exception e) {
+      lg.error("Failed to register with coordinator: {}", e.toString());
+      System.exit(1); // Exiting. Need a coordinator or nothing can be done.
     }
+  }
 }

--- a/src/org/vitrivr/cthulhu/worker/Worker.java
+++ b/src/org/vitrivr/cthulhu/worker/Worker.java
@@ -1,51 +1,74 @@
 package org.vitrivr.cthulhu.worker;
 
-import org.vitrivr.cthulhu.jobs.Job;
-
-import java.util.HashSet;
+import java.util.ArrayList;
 import java.util.Hashtable;
 import java.util.List;
-import java.util.stream.*;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+import org.vitrivr.cthulhu.jobs.Job;
 
-public class Worker{ 
-    String state;
-    String address;
-    int port;
-    int capacity; // Jobs that can be run simultaneously
-    Hashtable<String,Job> jt; // Job table
-    public Worker(String address, int port) {
-        this.address = address;
-        this.port = port;
-        this.capacity = 1; // Jobs that can be run simultaneously
-        jt = new Hashtable<String,Job>();
-    }
-    public Worker(String address, int port, int capacity) {
-        this.address = address;
-        this.port = port;
-        this.capacity = capacity;
-        jt = new Hashtable<String,Job>();
-    }
-    public List<Job> getJobs() {
-        return jt.entrySet().stream().map(e->e.getValue()).collect(Collectors.toList());
-    }
-    public Job getJob(String jobName) {
-        return jt.get(jobName);
-    }
-    public void addJob(Job job) {
-        jt.put(job.getName(),job);
-    }
-    public Job removeJob(String jobName) {
-        return jt.remove(jobName);
-    }
-    public boolean hasJob(String jobName) {
-        return jt.containsKey(jobName);
-    }
-    public Job deleteJob(String jobId) {
-        return jt.remove(jobId);
-    }
-    public int getCapacity() { return capacity; }
-    public int getJQSize() { return jt.size(); }
-    public String getAddress() { return address; }
-    public int getPort(){ return port; }
-    public String getId() { return address+":"+Integer.toString(port); }
+public class Worker {
+
+  private String address;
+  private int port;
+  private int capacity; // Jobs that can be run simultaneously
+  private Hashtable<String, Job> jt; // Job table
+
+  public Worker(String address, int port) {
+    this.address = address;
+    this.port = port;
+    this.capacity = 1; // Jobs that can be run simultaneously
+    jt = new Hashtable<>();
+  }
+
+  public Worker(String address, int port, int capacity) {
+    this.address = address;
+    this.port = port;
+    this.capacity = capacity;
+    jt = new Hashtable<>();
+  }
+
+  public List<Job> getJobs() {
+    return new ArrayList<>(jt.values());
+  }
+
+  public Job getJob(String jobName) {
+    return jt.get(jobName);
+  }
+
+  public void addJob(Job job) {
+    jt.put(job.getName(), job);
+  }
+
+  public Job removeJob(String jobName) {
+    return jt.remove(jobName);
+  }
+
+  public boolean hasJob(String jobName) {
+    return jt.containsKey(jobName);
+  }
+
+  public Job deleteJob(String jobId) {
+    return jt.remove(jobId);
+  }
+
+  public int getCapacity() {
+    return capacity;
+  }
+
+  public int getJQSize() {
+    return jt.size();
+  }
+
+  public String getAddress() {
+    return address;
+  }
+
+  public int getPort() {
+    return port;
+  }
+
+  public String getId() {
+    return address + ":" + port;
+  }
 }

--- a/test/org/vitrivr/cthulhu/jobs/BashJobTest.java
+++ b/test/org/vitrivr/cthulhu/jobs/BashJobTest.java
@@ -1,35 +1,39 @@
 package org.vitrivr.cthulhu.jobs;
 
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Test;
-import org.junit.BeforeClass;
-import org.junit.AfterClass;
-import static org.junit.Assert.*;
 
 public class BashJobTest {
-    private void runCheck(String command, String stdOut) {
-        runCheck(command,stdOut,null);
-    }
 
-    private void runCheck(String command, String stdOut, String stdErr) {
-        BashJob bj = new BashJob(command);
-        bj.execute();
-        if(stdOut != null) assertEquals(stdOut,bj.getStdOut());
-        if(stdErr != null) assertEquals(stdErr,bj.getStdErr());
-    }
+  private void runCheck(String command, String stdOut) {
+    runCheck(command, stdOut, null);
+  }
 
-    @Test
-    public void RunEcho() {
-        runCheck("echo pablo","pablo\n");
+  private void runCheck(String command, String stdOut, String stdErr) {
+    BashJob bj = new BashJob(command);
+    bj.execute();
+    if (stdOut != null) {
+      assertEquals(stdOut, bj.getStdOut());
     }
+    if (stdErr != null) {
+      assertEquals(stdErr, bj.getStdErr());
+    }
+  }
 
-    @Test
-    public void RunLarge() {
-        String twoEcho = 
-            "echo pablo\n"+
-            "echo was\n"+
+  @Test
+  public void RunEcho() {
+    runCheck("echo pablo", "pablo\n");
+  }
+
+  @Test
+  public void RunLarge() {
+    String twoEcho =
+        "echo pablo\n" +
+            "echo was\n" +
             "echo here";
-        BashJob bj = new BashJob(twoEcho);
-        bj.execute();
-        assertEquals("pablo\nwas\nhere\n",bj.getStdOut());
-    }
+    BashJob bj = new BashJob(twoEcho);
+    bj.execute();
+    assertEquals("pablo\nwas\nhere\n", bj.getStdOut());
+  }
 }

--- a/test/org/vitrivr/cthulhu/jobs/FeatureExtractionJobTest.java
+++ b/test/org/vitrivr/cthulhu/jobs/FeatureExtractionJobTest.java
@@ -17,6 +17,7 @@ import java.io.Reader;
 
 import org.apache.commons.io.IOUtils;
 
+import org.vitrivr.cthulhu.cineast.config.CineastConfig;
 import org.vitrivr.cthulhu.runners.CthulhuRunner;
 
 import com.google.gson.*;

--- a/test/org/vitrivr/cthulhu/jobs/FeatureExtractionJobTest.java
+++ b/test/org/vitrivr/cthulhu/jobs/FeatureExtractionJobTest.java
@@ -1,114 +1,114 @@
 package org.vitrivr.cthulhu.jobs;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.gson.Gson;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.util.Properties;
+import org.apache.commons.io.IOUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.junit.BeforeClass;
-import org.junit.AfterClass;
-import static org.junit.Assert.*;
-
-import java.util.Properties;
-
-import java.io.PrintWriter;
-import java.io.InputStream;
-import java.io.IOException;
-import java.io.FileReader;
-import java.io.BufferedReader;
-import java.io.Reader;
-
-import org.apache.commons.io.IOUtils;
-
 import org.vitrivr.cthulhu.cineast.config.CineastConfig;
 import org.vitrivr.cthulhu.runners.CthulhuRunner;
 
-import com.google.gson.*;
-import static org.mockito.Mockito.*;
-
 public class FeatureExtractionJobTest {
-    static JobFactory jf;
-    static JobTools jt;
-    static JobTools mockTools;
-    @BeforeClass
-    public static void setUpBeforeClass() throws Exception {
-        Properties props = new Properties();
-        try {
-            InputStream input = CthulhuRunner.class.getClassLoader().getResourceAsStream("cthulhu.properties");
-            props.load(input);
-        } catch (IOException io) {
-            throw new Exception("Could not read props");
-        }
-        CthulhuRunner.populateProperties(new String[0], props);
-        //PrintWriter writr = new PrintWriter(System.out);
-        //props.list(writr);
-        //writr.flush();
-        jt = new JobTools(props, null);
-        jf = new JobFactory();
-        jf.setTools(jt);
-        mockTools = mock(JobTools.class);
-        when(mockTools.getFile(any(), any())).thenReturn(true);
-        when(mockTools.delete(any())).thenCallRealMethod();
-        when(mockTools.setWorkingDirectory(any())).thenCallRealMethod();
-        mockTools.lg = jt.lg;
-        mockTools.props = jt.props;
-    }
 
-    @AfterClass
-    public static void tearDownAfterClass() {
-    }
+  private static JobFactory jf;
+  private static JobTools mockTools;
 
-    private String readWholeFile(String jsonFile) throws IOException {
-        String jsonRestore;
-        try {
-            InputStream is = Thread.currentThread().getContextClassLoader()
-                .getResourceAsStream(jsonFile);
-            jsonRestore = IOUtils.toString(is,"UTF-8");
-        } catch (IOException e) {
-            System.out.println("Unable to restore from file "+jsonFile+". Exception: "+e.toString());
-            throw e;
-        }
-        return jsonRestore;
+  @BeforeClass
+  public static void setUpBeforeClass() throws Exception {
+    Properties props = new Properties();
+    try {
+      InputStream input = CthulhuRunner.class.getClassLoader()
+          .getResourceAsStream("cthulhu.properties");
+      props.load(input);
+    } catch (IOException io) {
+      throw new Exception("Could not read props");
     }
+    CthulhuRunner.populateProperties(new String[0], props);
+    //PrintWriter writr = new PrintWriter(System.out);
+    //props.list(writr);
+    //writr.flush();
+    JobTools jt = new JobTools(props, null);
+    jf = new JobFactory();
+    jf.setTools(jt);
+    mockTools = mock(JobTools.class);
+    when(mockTools.getFile(any(), any())).thenReturn(true);
+    when(mockTools.delete(any())).thenCallRealMethod();
+    when(mockTools.setWorkingDirectory(any())).thenCallRealMethod();
+    mockTools.lg = jt.lg;
+    mockTools.props = jt.props;
+  }
 
-    @Test
-    public void makeDirectory() {
-        // Create job, with working directory, and then delete them
-        String json = "{\"type\":\"FeatureExtractionJob\",\"priority\":3, \"name\":\"fetujob\", \"immediate_cleanup\":true}";
-        Job jb = jf.buildJob(json);
-        jb.execute();
-    }
-    
-    @Test
-    public void makeConfigFile() throws Exception {
-        String json = "{\"type\":\"FeatureExtractionJob\",\"priority\":3, \"name\":\"configjob\"," +
-                           "\"immediate_cleanup\":\"false\", \"config\":{\"retriever\":\"aretriever\", " +
-                           "\"input\":{ \"id\":\"vidioid\", \"file\":\"file.avi\", \"name\":\"crazy vid\", " +
-                           " \"subtitles\": [\"subtitle1\", \"subtitle4\"]}}}";
-        FeatureExtractionJob jb = (FeatureExtractionJob) jf.buildJob(json);
-        jb.setTools(mockTools);
-        jb.execute();
-        Gson gson = new Gson();
-        String conFile = jb.workDir+"/"+jb.getName()+"_config.json";
-        Reader fr = new FileReader(conFile);
-        CineastConfig cc = gson.fromJson(fr, CineastConfig.class);
-        assertEquals(cc.retriever, "aretriever");
-        assertEquals(cc.input.id, "vidioid");
-        assertEquals(cc.input.file, "file.avi");
-        assertEquals(cc.input.subtitles.get(0), "subtitle1");
-        assertEquals(cc.input.subtitles.get(1), "subtitle4");
-        jb.deleteWorkingDirectory();
-    }
+  @AfterClass
+  public static void tearDownAfterClass() {
+  }
 
-    /**
-     * This is the test that will be fixed once the connection to Cineast is up to date.
-     * @throws Exception when the json file specified doesn't exist
-     */
-    @Test
-    @Ignore
-    public void withValidConfFile() throws IOException {
-        String json = readWholeFile("full_fe_job.json");
-        FeatureExtractionJob jb = (FeatureExtractionJob) jf.buildJob(json);
-        jb.execute();
-        //Gson gson = new Gson();
-        //System.out.println(gson.toJson(jb));
-        assertEquals(jb.getStatus(), 0); // Job succeeded
+  private String readWholeFile(String jsonFile) throws IOException {
+    String jsonRestore;
+    try {
+      InputStream is = Thread.currentThread().getContextClassLoader()
+          .getResourceAsStream(jsonFile);
+      jsonRestore = IOUtils.toString(is, "UTF-8");
+    } catch (IOException e) {
+      System.out
+          .println("Unable to restore from file " + jsonFile + ". Exception: " + e.toString());
+      throw e;
     }
+    return jsonRestore;
+  }
+
+  @Test
+  public void makeDirectory() {
+    // Create job, with working directory, and then delete them
+    String json = "{\"type\":\"FeatureExtractionJob\",\"priority\":3, \"name\":\"fetujob\", \"immediate_cleanup\":true}";
+    Job jb = jf.buildJob(json);
+    jb.execute();
+  }
+
+  @Test
+  public void makeConfigFile() throws Exception {
+    String json = "{\"type\":\"FeatureExtractionJob\",\"priority\":3, \"name\":\"configjob\"," +
+        "\"immediate_cleanup\":\"false\", \"config\":{\"retriever\":\"aretriever\", " +
+        "\"input\":{ \"id\":\"vidioid\", \"file\":\"file.avi\", \"name\":\"crazy vid\", " +
+        " \"subtitles\": [\"subtitle1\", \"subtitle4\"]}}}";
+    FeatureExtractionJob jb = (FeatureExtractionJob) jf.buildJob(json);
+    jb.setTools(mockTools);
+    jb.execute();
+    Gson gson = new Gson();
+    String conFile = jb.workDir + "/" + jb.getName() + "_config.json";
+    Reader fr = new FileReader(conFile);
+    CineastConfig cc = gson.fromJson(fr, CineastConfig.class);
+    assertEquals("aretriever", cc.retriever);
+    assertEquals("vidioid", cc.input.id);
+    assertEquals("file.avi", cc.input.file);
+    assertEquals("subtitle1", cc.input.subtitles.get(0));
+    assertEquals("subtitle4", cc.input.subtitles.get(1));
+    jb.deleteWorkingDirectory();
+  }
+
+  /**
+   * This is the test that will be fixed once the connection to Cineast is up to date.
+   *
+   * @throws IOException when the json file specified doesn't exist
+   */
+  @Test
+  @Ignore
+  public void withValidConfFile() throws IOException {
+    String json = readWholeFile("full_fe_job.json");
+    FeatureExtractionJob jb = (FeatureExtractionJob) jf.buildJob(json);
+    jb.execute();
+    //Gson gson = new Gson();
+    //System.out.println(gson.toJson(jb));
+    assertEquals(0, jb.getStatus()); // Job succeeded
+  }
 }

--- a/test/org/vitrivr/cthulhu/jobs/JobFactoryTest.java
+++ b/test/org/vitrivr/cthulhu/jobs/JobFactoryTest.java
@@ -1,62 +1,65 @@
 package org.vitrivr.cthulhu.jobs;
 
-import org.junit.Test;
-import org.junit.BeforeClass;
-import org.junit.AfterClass;
-import org.junit.Rule;
-import org.junit.rules.ExpectedException;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
-import com.google.gson.*;
+import com.google.gson.JsonParseException;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 public class JobFactoryTest {
-    static JobFactory jf;
-    @Rule
-    public final ExpectedException exception = ExpectedException.none();
 
-    @BeforeClass
-    public static void setUpBeforeClass() throws Exception {
-        jf = new JobFactory();
-    }
+  private static JobFactory jf;
+  @Rule
+  public final ExpectedException exception = ExpectedException.none();
 
-    @AfterClass
-    public static void tearDownAfterClass() throws Exception {
-    }
+  @BeforeClass
+  public static void setUpBeforeClass() {
+    jf = new JobFactory();
+  }
 
-    @Test
-    public void buildBasic() {
-        String json = "{\"type\":\"BashJob\"}";
-        Job job = jf.buildJob(json);
-        assertEquals(job.getClass(), BashJob.class);
-    }
-    @Test
-    public void defaultPriority() {
-        String json = "{\"type\":\"BashJob\"}";
-        Job job = jf.buildJob(json);
-        assertEquals(job.getPriority(), 2);
-    }
-    @Test
-    public void customPriority() {
-        String json = "{\"type\":\"BashJob\",\"priority\":3}";
-        Job job = jf.buildJob(json);
-        assertEquals(job.getPriority(), 3);
-    }
-    @Test
-    public void bashType() {
-        String json = "{\"type\":\"BashJob\",\"priority\":3}";
-        Job job = jf.buildJob(json);
-        assertEquals(job.getType(), "BashJob");
-    }
-    @Test
-    public void typelessJob() {
-        String json = "{\"priority\":3}";
-        exception.expect(JsonParseException.class);
-        Job job = jf.buildJob(json);
-    }
-    @Test
-    public void malformedJob() {
-        String json = "Paoufbivsett}";
-        exception.expect(JsonParseException.class);
-        Job job = jf.buildJob(json);
-    }
+  @Test
+  public void buildBasic() {
+    String json = "{\"type\":\"BashJob\"}";
+    Job job = jf.buildJob(json);
+    assertEquals(job.getClass(), BashJob.class);
+  }
+
+  @Test
+  public void defaultPriority() {
+    String json = "{\"type\":\"BashJob\"}";
+    Job job = jf.buildJob(json);
+    assertEquals(2, job.getPriority());
+  }
+
+  @Test
+  public void customPriority() {
+    String json = "{\"type\":\"BashJob\",\"priority\":3}";
+    Job job = jf.buildJob(json);
+    assertEquals(3, job.getPriority());
+  }
+
+  @Test
+  public void bashType() {
+    String json = "{\"type\":\"BashJob\",\"priority\":3}";
+    Job job = jf.buildJob(json);
+    assertTrue(job instanceof BashJob);
+  }
+
+  @Test
+  public void typelessJob() {
+    String json = "{\"priority\":3}";
+    exception.expect(JsonParseException.class);
+    jf.buildJob(json);
+  }
+
+  @Test
+  public void malformedJob() {
+    String json = "Paoufbivsett}";
+    exception.expect(JsonParseException.class);
+    jf.buildJob(json);
+  }
 }

--- a/test/org/vitrivr/cthulhu/jobs/JobQueueTest.java
+++ b/test/org/vitrivr/cthulhu/jobs/JobQueueTest.java
@@ -1,52 +1,53 @@
 package org.vitrivr.cthulhu.jobs;
 
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.BeforeClass;
-import org.junit.AfterClass;
-import static org.junit.Assert.*;
+import org.junit.Test;
 
 public class JobQueueTest {
-    @BeforeClass
-    public static void setUpBeforeClass() throws Exception {
+
+  @BeforeClass
+  public static void setUpBeforeClass() {
+  }
+
+  @Test
+  public void BasicTest() {
+    JobQueue jq = new JobQueue();
+    BashJob lowPri = new BashJob("", 2); // Low priority job
+    BashJob hiestPri = new BashJob("", 0); // Second high priority job
+    BashJob hiPri = new BashJob("", 1); // High priority job
+
+    jq.push(lowPri);
+    jq.push(hiestPri);
+    jq.push(hiPri);
+    assertEquals(hiestPri, jq.pop());
+    assertEquals(hiPri, jq.pop());
+    assertEquals(lowPri, jq.pop());
+  }
+
+  @Test
+  public void CreatedTimeTest() {
+    JobQueue jq = new JobQueue();
+    BashJob lowPri = new BashJob("", 2); // Low priority job
+    try {
+      Thread.sleep(100);
+    } catch (InterruptedException ex) {
+      Thread.currentThread().interrupt();
     }
-
-    @Test
-    public void BasicTest() {
-        JobQueue jq = new JobQueue();
-        BashJob lowPri = new BashJob("",2); // Low priority job
-        BashJob hiestPri = new BashJob("",0); // Second high priority job        
-        BashJob hiPri = new BashJob("",1); // High priority job
-
-        jq.push(lowPri);
-        jq.push(hiestPri);
-        jq.push(hiPri);
-        assertEquals(hiestPri, jq.pop());
-        assertEquals(hiPri,jq.pop());
-        assertEquals(lowPri,jq.pop());
+    BashJob laterLowPri = new BashJob("", 2); // Second high priority job
+    try {
+      Thread.sleep(100);
+    } catch (InterruptedException ex) {
+      Thread.currentThread().interrupt();
     }
+    BashJob latestLowPri = new BashJob("", 2);
 
-    @Test
-    public void CreatedTimeTest() {
-        JobQueue jq = new JobQueue();
-        BashJob lowPri = new BashJob("",2); // Low priority job
-        try {
-            Thread.sleep(100);
-        } catch(InterruptedException ex) {
-            Thread.currentThread().interrupt();
-        }
-        BashJob laterLowPri = new BashJob("",2); // Second high priority job
-        try {
-            Thread.sleep(100);
-        } catch(InterruptedException ex) {
-            Thread.currentThread().interrupt();
-        }
-        BashJob latestLowPri = new BashJob("",2);
-
-        jq.push(latestLowPri);
-        jq.push(lowPri);
-        jq.push(laterLowPri);
-        assertEquals(lowPri,jq.pop());
-        assertEquals(laterLowPri, jq.pop());
-        assertEquals(latestLowPri, jq.pop());
-    }
+    jq.push(latestLowPri);
+    jq.push(lowPri);
+    jq.push(laterLowPri);
+    assertEquals(lowPri, jq.pop());
+    assertEquals(laterLowPri, jq.pop());
+    assertEquals(latestLowPri, jq.pop());
+  }
 }

--- a/test/org/vitrivr/cthulhu/scheduler/CoordinatorSchedulerTest.java
+++ b/test/org/vitrivr/cthulhu/scheduler/CoordinatorSchedulerTest.java
@@ -1,200 +1,219 @@
 package org.vitrivr.cthulhu.scheduler;
 
-import org.apache.commons.io.IOUtils;
-import java.io.FileInputStream;
-import java.io.InputStream;
-
-import org.junit.Test;
-import org.junit.BeforeClass;
-import org.junit.AfterClass;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.commons.io.IOUtils;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.vitrivr.cthulhu.jobs.Job;
 import org.vitrivr.cthulhu.jobs.JobAdapter;
-import org.vitrivr.cthulhu.jobs.Job;
-import org.vitrivr.cthulhu.worker.Worker;
-
-import org.vitrivr.cthulhu.jobs.Job;
 import org.vitrivr.cthulhu.jobs.JobFactory;
 import org.vitrivr.cthulhu.rest.CthulhuRESTConnector;
-
-import java.util.stream.Collectors;
-import java.util.Arrays;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.List;
-
-import static org.mockito.Mockito.*;
+import org.vitrivr.cthulhu.worker.Worker;
 
 public class CoordinatorSchedulerTest {
-    static JobFactory jf;
-    static Gson gson;
-    @BeforeClass
-    public static void setupBeforeClass() {
-        jf = new JobFactory();
-        gson = new Gson();
-    }
 
-    private void addMockCall(CthulhuRESTConnector mockonnector, Worker inWorker, String returnList) {
-        try {
-            when(mockonnector.getJobs(inWorker)).thenReturn(returnList);
-        } catch (Exception e) {
-            System.out.println("problem mocking the CthulhuRESTConnector");
-        }
-    }
-    
-    /** This takes in the two arguments for the mock connector's getJobs method,
-        and the expected return value */
-    private CthulhuRESTConnector mockConnectorGetJobs(Worker inWorker, String returnList) {
-        CthulhuRESTConnector mockonnector = mock(CthulhuRESTConnector.class);
-        addMockCall(mockonnector, inWorker, returnList);
-        return mockonnector;
-    }
+  private static JobFactory jf;
 
-    private String readWholeFile(String jsonFile) throws Exception {
-        String jsonRestore;
-        try {
-            InputStream is = Thread.currentThread().getContextClassLoader()
-                .getResourceAsStream(jsonFile);
-            jsonRestore = IOUtils.toString(is,"UTF-8");
-        } catch (Exception e) {
-            System.out.println("Unable to restore from file "+jsonFile+". Exception: "+e.toString());
-            throw e;
-        }
-        return jsonRestore;
-    }
+  @BeforeClass
+  public static void setupBeforeClass() {
+    jf = new JobFactory();
+  }
 
-    private List<Job> joblistFromFile(String jsonFile) throws Exception {
-        String jsonRestore = readWholeFile(jsonFile);
-        return jf.buildJobs(jsonRestore);
+  private void addMockCall(CthulhuRESTConnector mockonnector, Worker inWorker, String returnList) {
+    try {
+      when(mockonnector.getJobs(inWorker)).thenReturn(returnList);
+    } catch (Exception e) {
+      System.out.println("problem mocking the CthulhuRESTConnector");
     }
-    private CoordinatorScheduler restoreFromFile(String jsonFile) throws Exception {
-        String jsonRestore = readWholeFile(jsonFile);
-        Gson restoreGson = new GsonBuilder()
-            .registerTypeAdapter(Job.class, new JobAdapter())
-            .create();
-        CoordinatorScheduler rs = restoreGson.fromJson(jsonRestore, CoordinatorScheduler.class);
-        return rs;
-    }
+  }
 
-    /** Helper function for restoreTestJobDone */
-    private CoordinatorScheduler runJobDoneTest(int jobStatus, String jobListFile, int finalJQSize, String mainFile) 
-        throws Exception {
-        CoordinatorScheduler rs = restoreFromFile(mainFile);
-        String resultJobs = readWholeFile(jobListFile);
-        //System.out.println(gson.toJson(rs));
-        CthulhuRESTConnector nwConn = mockConnectorGetJobs(rs.getWorkers("147.46.117.72:8081"),resultJobs);
-        rs.setConn(nwConn);
-        assertEquals(rs.getJobs().size(),1); // Restoring a single job
-        assertEquals(rs.jq.size(),0); // No jobs on the queue
-        assertEquals(rs.getJobs().get(0).getStatus(), Job.Status.RUNNING.getValue()); // Before checking job is running
+  /**
+   * This takes in the two arguments for the mock connector's getJobs method, and the expected
+   * return value
+   */
+  private CthulhuRESTConnector mockConnectorGetJobs(Worker inWorker, String returnList) {
+    CthulhuRESTConnector mockConnector = mock(CthulhuRESTConnector.class);
+    addMockCall(mockConnector, inWorker, returnList);
+    return mockConnector;
+  }
 
-        rs.restoreStatus();
-        //System.out.println(gson.toJson(rs));
-        assertEquals(rs.getJobs().size(),1); // Restoring a single job
-        assertEquals(rs.jq.size(),finalJQSize); // No jobs added to the queue
-        assertEquals(rs.getJobs().get(0).getStatus(), jobStatus); // Before checking job is DONE
-        return rs;
+  private String readWholeFile(String jsonFile) throws Exception {
+    String jsonRestore;
+    try {
+      InputStream is = Thread.currentThread().getContextClassLoader()
+          .getResourceAsStream(jsonFile);
+      jsonRestore = IOUtils.toString(is, "UTF-8");
+    } catch (Exception e) {
+      System.out
+          .println("Unable to restore from file " + jsonFile + ". Exception: " + e.toString());
+      throw e;
     }
+    return jsonRestore;
+  }
 
-    @Test
-    public void restoreTestSimple() throws Exception{
-        /* RESTORING Two waiting jobs, and no workers at all
-         * RESULT: Both are added to the job queue and that's it
-         *
-         * Im short, this is the case where no workers exist, thus jobs are simply recovered and enqueued
-         */
-        CoordinatorScheduler rs = restoreFromFile("testRestore1.json");
-        // At this point the job queue should be empty, and all jobs must be waitin
-        assertEquals(rs.jq.size(),0);
-        rs.getJobs().stream().forEach(j->{ assertTrue(j.isWaiting()); });
-        rs.restoreStatus();
-        assertEquals(rs.jq.size(),2);
-    }
+  private List<Job> joblistFromFile(String jsonFile) throws Exception {
+    String jsonRestore = readWholeFile(jsonFile);
+    return jf.buildJobs(jsonRestore);
+  }
 
-    @Test
-    public void restoreTestJobDone() throws Exception{
-        /* RESTORING: Coord restore: One running job in one worker
-         * Worker responds: Running job has SUCCEEDED, then INTERRUPTED, then FAILED, then ERROR
-         * RESULT: Job is saved as having succeeded and so on.
-         *
-         * In short, this is the case where a job finished running while we recovered
-         */
-        runJobDoneTest(Job.Status.SUCCEEDED.getValue(), "testJobListA.json",0,"testRestore2.json");
-        runJobDoneTest(Job.Status.INTERRUPTED.getValue(), "testJobListAInterrupted.json",0,"testRestore2.json");
-        runJobDoneTest(Job.Status.FAILED.getValue(), "testJobListAFailed.json",0,"testRestore2.json");
-        //runJobDoneTest(Job.Status.UNEXPECTED_ERROR.getValue(), "testJobListA.json");
-    }
+  private CoordinatorScheduler restoreFromFile(String jsonFile) throws Exception {
+    String jsonRestore = readWholeFile(jsonFile);
+    Gson restoreGson = new GsonBuilder()
+        .registerTypeAdapter(Job.class, new JobAdapter())
+        .create();
+    CoordinatorScheduler rs = restoreGson.fromJson(jsonRestore, CoordinatorScheduler.class);
+    return rs;
+  }
 
-    @Test
-    public void restoreTestJobRunDone() throws Exception {
-        /* RESTORING: Coord restore: Two running jobs in same worker
-         * Worker responds: One running job has succeeded, the other has failed
-         * RESULT: Both are saved as failed and succeeded, and not put in the job queue
-         */
-        CoordinatorScheduler rs = restoreFromFile("testRestore3.json");
-        String resultJobs = readWholeFile("testJobList3-1.json");
-        CthulhuRESTConnector nwConn = mockConnectorGetJobs(rs.getWorkers("147.46.117.72:8081"),resultJobs);
-        rs.setConn(nwConn);
-        assertEquals(rs.getJobs().size(),3); // Restoring three jobs
-        assertEquals(rs.jq.size(),0); // No jobs on the queue
-        // Two running jobs, one waiting job
-        Set<Integer> st = new HashSet<Integer>(Arrays.asList(Job.Status.RUNNING.getValue(), 
-                                                             Job.Status.RUNNING.getValue(),
-                                                             Job.Status.WAITING.getValue()));
-        Set<Integer> rsSt = rs.getJobs().stream().map(j->j.getStatus()).collect(Collectors.toSet());
-        assertTrue(rsSt.containsAll(st));
-        assertEquals(rsSt.size(),st.size());
-        rs.restoreStatus();
-        assertEquals(rs.jq.size(),1); // No jobs on the queue        
-        rsSt = rs.getJobs().stream().map(j->j.getStatus()).collect(Collectors.toSet());
-        st = new HashSet<Integer>(Arrays.asList(Job.Status.RUNNING.getValue(), 
-                                                Job.Status.SUCCEEDED.getValue(),
-                                                Job.Status.WAITING.getValue()));
-        assertTrue(rsSt.containsAll(st));
-        assertEquals(rsSt.size(),st.size());
-        assertEquals(rs.getJobs("pabs2").getStatus(), Job.Status.SUCCEEDED.getValue());
-        assertEquals(rs.getJobs("pabs").getStatus(), Job.Status.RUNNING.getValue());
-    }
+  /**
+   * Helper function for restoreTestJobDone
+   */
+  private CoordinatorScheduler runJobDoneTest(
+      int jobStatus,
+      String jobListFile,
+      int finalJQSize,
+      String mainFile)
+      throws Exception {
+    CoordinatorScheduler rs = restoreFromFile(mainFile);
+    String resultJobs = readWholeFile(jobListFile);
+    //System.out.println(gson.toJson(rs));
+    CthulhuRESTConnector nwConn = mockConnectorGetJobs(
+        rs.getWorkers("147.46.117.72:8081"),
+        resultJobs);
+    rs.setConn(nwConn);
+    assertEquals(1, rs.getJobs().size()); // Restoring a single job
+    assertEquals(0, rs.jq.size()); // No jobs on the queue
+    assertEquals(
+        Job.Status.RUNNING.getValue(),
+        rs.getJobs().get(0).getStatus()); // Before checking job is running
 
-    @Test
-    public void restoreTestWorkerLost() throws Exception {
-        /* RESTORING: Coord restore: Two running jobs in two different workers
-         * Worker 1 responds: One running job is still running
-         * Worker 2 does not respond: We assume that its job has been lost
-         * RESULT: Job in worker 1 is saved as running. Job in worker 2 is readded to the job queue, worker 2 is removed.
-         */
-        CoordinatorScheduler rs = restoreFromFile("testRestore4.json");
-        String resultJobs = readWholeFile("testJobList4-1.json");
-        CthulhuRESTConnector nwConn = mockConnectorGetJobs(rs.getWorkers("147.46.117.72:8081"),resultJobs);
-        when(nwConn.getJobs(rs.getWorkers("147.46.117.72:8083"))).thenThrow(new Exception("Lost the workah"));
-        rs.setConn(nwConn);
-        assertEquals(rs.getJobs().size(),3); // Restoring three jobs
-        assertEquals(rs.jq.size(),0); // No jobs on the queue
-        assertEquals(rs.getWorkers().size(),2);
-        // Two running jobs, one waiting job
-        Set<Integer> st = new HashSet<Integer>(Arrays.asList(Job.Status.RUNNING.getValue(), 
-                                                             Job.Status.RUNNING.getValue(),
-                                                             Job.Status.WAITING.getValue()));
-        Set<Integer> rsSt = rs.getJobs().stream().map(j->j.getStatus()).collect(Collectors.toSet());
-        assertTrue(rsSt.containsAll(st));
-        assertEquals(rsSt.size(),st.size());
-        //System.out.println(gson.toJson(rs));
-        rs.restoreStatus();
-        //System.out.println(gson.toJson(rs));
-        assertEquals(rs.getWorkers().size(),1);
-        assertEquals(rs.getWorkers("147.46.117.72:8083"),null);
-        assertEquals(rs.getWorkers("147.46.117.72:8081").getId(),"147.46.117.72:8081");
-        assertEquals(rs.jq.size(),2); // Two jobs on the queue
-        rsSt = rs.getJobs().stream().map(j->j.getStatus()).collect(Collectors.toSet());
-        st = new HashSet<Integer>(Arrays.asList(Job.Status.RUNNING.getValue(), 
-                                                Job.Status.WAITING.getValue(),
-                                                Job.Status.WAITING.getValue()));
-        assertTrue(rsSt.containsAll(st));
-        assertEquals(rsSt.size(),st.size());
-        assertEquals(rs.getJobs("pabs2").getStatus(), Job.Status.WAITING.getValue());
-        assertEquals(rs.getJobs("pabs").getStatus(), Job.Status.RUNNING.getValue());
-    }
+    rs.restoreStatus();
+    //System.out.println(gson.toJson(rs));
+    assertEquals(1, rs.getJobs().size()); // Restoring a single job
+    assertEquals(finalJQSize, rs.jq.size()); // No jobs added to the queue
+    assertEquals(jobStatus, rs.getJobs().get(0).getStatus()); // Before checking job is DONE
+    return rs;
+  }
+
+  @Test
+  public void restoreTestSimple() throws Exception {
+    /* RESTORING Two waiting jobs, and no workers at all
+     * RESULT: Both are added to the job queue and that's it
+     *
+     * Im short, this is the case where no workers exist, thus jobs are simply recovered and enqueued
+     */
+    CoordinatorScheduler rs = restoreFromFile("testRestore1.json");
+    // At this point the job queue should be empty, and all jobs must be waitin
+    assertEquals(0, rs.jq.size());
+    rs.getJobs().forEach(j -> assertTrue(j.isWaiting()));
+    rs.restoreStatus();
+    assertEquals(2, rs.jq.size());
+  }
+
+  @Test
+  public void restoreTestJobDone() throws Exception {
+    /* RESTORING: Coord restore: One running job in one worker
+     * Worker responds: Running job has SUCCEEDED, then INTERRUPTED, then FAILED, then ERROR
+     * RESULT: Job is saved as having succeeded and so on.
+     *
+     * In short, this is the case where a job finished running while we recovered
+     */
+    runJobDoneTest(Job.Status.SUCCEEDED.getValue(), "testJobListA.json", 0, "testRestore2.json");
+    runJobDoneTest(Job.Status.INTERRUPTED.getValue(), "testJobListAInterrupted.json", 0,
+                   "testRestore2.json");
+    runJobDoneTest(Job.Status.FAILED.getValue(), "testJobListAFailed.json", 0, "testRestore2.json");
+    //runJobDoneTest(Job.Status.UNEXPECTED_ERROR.getValue(), "testJobListA.json");
+  }
+
+  @Test
+  public void restoreTestJobRunDone() throws Exception {
+    /* RESTORING: Coord restore: Two running jobs in same worker
+     * Worker responds: One running job has succeeded, the other has failed
+     * RESULT: Both are saved as failed and succeeded, and not put in the job queue
+     */
+    CoordinatorScheduler rs = restoreFromFile("testRestore3.json");
+    String resultJobs = readWholeFile("testJobList3-1.json");
+    CthulhuRESTConnector nwConn = mockConnectorGetJobs(
+        rs.getWorkers("147.46.117.72:8081"),
+        resultJobs);
+    rs.setConn(nwConn);
+    assertEquals(3, rs.getJobs().size()); // Restoring three jobs
+    assertEquals(0, rs.jq.size()); // No jobs on the queue
+    // Two running jobs, one waiting job
+    Set<Integer> st = new HashSet<>(Arrays.asList(
+        Job.Status.RUNNING.getValue(),
+        Job.Status.RUNNING.getValue(),
+        Job.Status.WAITING.getValue()));
+    Set<Integer> rsSt = rs.getJobs().stream().map(Job::getStatus).collect(Collectors.toSet());
+    assertTrue(rsSt.containsAll(st));
+    assertEquals(st.size(), rsSt.size());
+    rs.restoreStatus();
+    assertEquals(1, rs.jq.size()); // No jobs on the queue
+    rsSt = rs.getJobs().stream().map(Job::getStatus).collect(Collectors.toSet());
+    st = new HashSet<>(Arrays.asList(
+        Job.Status.RUNNING.getValue(),
+        Job.Status.SUCCEEDED.getValue(),
+        Job.Status.WAITING.getValue()));
+    assertTrue(rsSt.containsAll(st));
+    assertEquals(st.size(), rsSt.size());
+    assertEquals(Job.Status.SUCCEEDED.getValue(), rs.getJobs("pabs2").getStatus());
+    assertEquals(Job.Status.RUNNING.getValue(), rs.getJobs("pabs").getStatus());
+  }
+
+  @Test
+  public void restoreTestWorkerLost() throws Exception {
+    /* RESTORING: Coord restore: Two running jobs in two different workers
+     * Worker 1 responds: One running job is still running
+     * Worker 2 does not respond: We assume that its job has been lost
+     * RESULT: Job in worker 1 is saved as running. Job in worker 2 is readded to the job queue, worker 2 is removed.
+     */
+    CoordinatorScheduler rs = restoreFromFile("testRestore4.json");
+    String resultJobs = readWholeFile("testJobList4-1.json");
+    CthulhuRESTConnector nwConn = mockConnectorGetJobs(
+        rs.getWorkers("147.46.117.72:8081"),
+        resultJobs);
+    when(nwConn.getJobs(rs.getWorkers("147.46.117.72:8083")))
+        .thenThrow(new Exception("Lost the workah"));
+    rs.setConn(nwConn);
+    assertEquals(3, rs.getJobs().size()); // Restoring three jobs
+    assertEquals(0, rs.jq.size()); // No jobs on the queue
+    assertEquals(2, rs.getWorkers().size());
+    // Two running jobs, one waiting job
+    Set<Integer> st = new HashSet<>(Arrays.asList(
+        Job.Status.RUNNING.getValue(),
+        Job.Status.RUNNING.getValue(),
+        Job.Status.WAITING.getValue()));
+    Set<Integer> rsSt = rs.getJobs().stream().map(Job::getStatus).collect(Collectors.toSet());
+    assertTrue(rsSt.containsAll(st));
+    assertEquals(st.size(), rsSt.size());
+    //System.out.println(gson.toJson(rs));
+    rs.restoreStatus();
+    //System.out.println(gson.toJson(rs));
+    assertEquals(1, rs.getWorkers().size());
+    assertNull(rs.getWorkers("147.46.117.72:8083"));
+    assertEquals("147.46.117.72:8081", rs.getWorkers("147.46.117.72:8081").getId());
+    assertEquals(2, rs.jq.size()); // Two jobs on the queue
+    rsSt = rs.getJobs().stream().map(Job::getStatus).collect(Collectors.toSet());
+    st = new HashSet<>(Arrays.asList(
+        Job.Status.RUNNING.getValue(),
+        Job.Status.WAITING.getValue(),
+        Job.Status.WAITING.getValue()));
+    assertTrue(rsSt.containsAll(st));
+    assertEquals(rsSt.size(), st.size());
+    assertEquals(Job.Status.WAITING.getValue(), rs.getJobs("pabs2").getStatus());
+    assertEquals(Job.Status.RUNNING.getValue(), rs.getJobs("pabs").getStatus());
+  }
 }

--- a/test/org/vitrivr/cthulhu/scheduler/WorkerSchedulerTest.java
+++ b/test/org/vitrivr/cthulhu/scheduler/WorkerSchedulerTest.java
@@ -1,39 +1,36 @@
 package org.vitrivr.cthulhu.scheduler;
 
-import org.junit.Test;
-import org.junit.BeforeClass;
-import org.junit.AfterClass;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNull;
 
+import org.junit.BeforeClass;
+import org.junit.Test;
 import org.vitrivr.cthulhu.jobs.Job;
 import org.vitrivr.cthulhu.jobs.JobFactory;
 
-import java.util.stream.Collectors;
-import java.util.Arrays;
-import java.util.ArrayList;
-import java.util.Set;
-
 public class WorkerSchedulerTest {
-    static CthulhuScheduler ms;
-    static JobFactory jf;
-    @BeforeClass
-    public static void setupBeforeClass() {
-        ms = new WorkerScheduler(null,true); // Do not register
-        jf = new JobFactory();
+
+  private static CthulhuScheduler ms;
+
+  @BeforeClass
+  public static void setupBeforeClass() {
+    ms = new WorkerScheduler(null, true); // Do not register
+  }
+
+  @Test
+  public void registerDeleteJob() {
+    String jobDef = "{\"type\":\"BashJob\",\"action\":\"sleep 20\",\"name\":\"wahJob\"}";
+    ms.registerJob(jobDef);
+    Job jb;
+    //Job jb = ms.getJobs("wahJob");
+    try {
+      Thread.sleep(5000);
+    } catch (Exception e) { /* Ignoring */}
+    try {
+      ms.deleteJob("wahJob", true);
+    } catch (Exception e) {
+      System.out.println("Deleted.");
     }
-    @Test
-    public void registerDeleteJob() {
-        String jobDef = "{\"type\":\"BashJob\",\"action\":\"sleep 20\",\"name\":\"wahJob\"}";
-        ms.registerJob(jobDef);
-        Job jb;
-        //Job jb = ms.getJobs("wahJob");
-        try { Thread.sleep(5000); } catch (Exception e) { /* Ignoring */}
-        try {
-            Job rm = ms.deleteJob("wahJob", true);
-        } catch (Exception e) {
-            System.out.println("Deleted.");
-        }
-        jb = ms.getJobs("wahJob");
-        assertEquals(jb,null);
-    }
+    jb = ms.getJobs("wahJob");
+    assertNull(jb);
+  }
 }


### PR DESCRIPTION
* Change indentation to 2 spaces to match Cineast's format
* Remove try catches that just re-throw the error
* Replace try catches with `try with` blocks when necessary
* Add error logging for when thrown errors are caught and ignored (a placeholder for proper error handling)
* Move Cineast config to its own configuration folder
* Re-order imports
> No logic changes
* Properly arrange test assertions:
```java
assertEquals(expectation, actual);
```